### PR TITLE
feat: add /dev/null and /dev/zero devices to devfs

### DIFF
--- a/kernel/src/file/devfs.rs
+++ b/kernel/src/file/devfs.rs
@@ -1,7 +1,7 @@
 use core::fmt::Write;
 
 use conquer_once::spin::OnceCell;
-use kernel_devfs::{ArcLockedDevFs, Null, Serial};
+use kernel_devfs::{ArcLockedDevFs, Null, Serial, Zero};
 use kernel_vfs::path::AbsolutePath;
 
 use crate::serial_print;
@@ -37,6 +37,14 @@ pub fn init() {
                 Ok(Serial::<SerialWrite>::default())
             })
             .expect("should be able to register stderr");
+
+        guard
+            .register_file(AbsolutePath::try_new("/null").unwrap(), || Ok(Null))
+            .expect("should be able to register /null");
+
+        guard
+            .register_file(AbsolutePath::try_new("/zero").unwrap(), || Ok(Zero))
+            .expect("should be able to register /zero");
     }
     DEVFS.init_once(|| devfs);
 }


### PR DESCRIPTION
Implements missing standard Unix device files in the device filesystem. The Zero and Null device implementations already existed in kernel_devfs but were not registered as accessible device files.

Changes:
- Register /dev/null: discards all writes, returns EOF on reads
- Register /dev/zero: discards all writes, returns zeros on reads
- Import Zero type from kernel_devfs crate

These devices are standard on Unix-like systems and useful for userspace programs that need null device or zero-filled buffers.