### PR TITLE
feat(aarch64): complete ARM64 JIT instruction emission

### DIFF
--- a/kernel/crates/kernel_bpf/src/execution/mod.rs
+++ b/kernel/crates/kernel_bpf/src/execution/mod.rs
@@ -22,12 +22,12 @@ mod interpreter;
 #[cfg(all(feature = "cloud-profile", target_arch = "x86_64"))]
 pub mod jit;
 
-// ARM64 JIT is available for both profiles (primary target for robotics)
-#[cfg(target_arch = "aarch64")]
+// ARM64 JIT is available for aarch64 target or for testing on any platform
+#[cfg(any(target_arch = "aarch64", test))]
 pub mod jit_aarch64;
 
 pub use interpreter::Interpreter;
-#[cfg(target_arch = "aarch64")]
+#[cfg(any(target_arch = "aarch64", test))]
 pub use jit_aarch64::{Arm64JitCompiler, Arm64JitExecutor};
 
 use crate::bytecode::program::BpfProgram;


### PR DESCRIPTION
- Fix hardcoded 512-byte stack size to use profile MAX_STACK_SIZE
- Implement CALL instruction with BLR for BPF helper dispatch
- Implement JSET instruction using TST + conditional branch
- Implement END (byte swap) using REV/REV16/REV32 instructions
- Fix LD_IMM64 to properly combine two 32-bit immediates
- Add 32-bit ALU truncation via UXTW zero-extension
- Add new emitter methods: emit_blr, emit_tst_reg, emit_rev*
- Enable ARM64 JIT module for testing on all platforms
- Add 16 comprehensive tests for JIT compilation