### PR TITLE
feat(syscall): implement close, lseek, and fstat syscalls

### DIFF
--- a/kernel/crates/kernel_syscall/src/fcntl.rs
+++ b/kernel/crates/kernel_syscall/src/fcntl.rs
@@ -93,6 +93,7 @@ mod tests {
         type ReadError = F::ReadError;
         type WriteError = F::WriteError;
         type CloseError = F::CloseError;
+        type LseekError = F::LseekError;
 
         fn file_info(&self, path: &AbsolutePath) -> Option<Self::FileInfo> {
             self.file_access.file_info(path)
@@ -112,6 +113,10 @@ mod tests {
 
         fn close(&self, fd: Self::Fd) -> Result<(), Self::CloseError> {
             self.file_access.close(fd)
+        }
+
+        fn lseek(&self, fd: Self::Fd, offset: i64, whence: i32) -> Result<usize, Self::LseekError> {
+            self.file_access.lseek(fd, offset, whence)
         }
     }
 

--- a/kernel/crates/kernel_syscall/src/lib.rs
+++ b/kernel/crates/kernel_syscall/src/lib.rs
@@ -5,6 +5,7 @@ extern crate alloc;
 pub mod access;
 pub mod fcntl;
 pub mod mman;
+pub mod stat;
 pub mod unistd;
 
 mod ptr;

--- a/kernel/crates/kernel_syscall/src/stat.rs
+++ b/kernel/crates/kernel_syscall/src/stat.rs
@@ -1,0 +1,96 @@
+//! stat/fstat syscall implementations
+
+use kernel_abi::{EBADF, EINVAL, Errno};
+
+use crate::access::FileAccess;
+use crate::ptr::UserspaceMutPtr;
+
+/// Linux stat structure (simplified for now)
+#[repr(C)]
+#[derive(Debug, Default, Clone, Copy)]
+pub struct UserStat {
+    /// Device ID
+    pub st_dev: u64,
+    /// Inode number
+    pub st_ino: u64,
+    /// Number of hard links
+    pub st_nlink: u64,
+    /// File mode (permissions and type)
+    pub st_mode: u32,
+    /// User ID of owner
+    pub st_uid: u32,
+    /// Group ID of owner
+    pub st_gid: u32,
+    /// Padding
+    pub __pad0: u32,
+    /// Device ID (if special file)
+    pub st_rdev: u64,
+    /// Total size in bytes
+    pub st_size: i64,
+    /// Block size for filesystem I/O
+    pub st_blksize: i64,
+    /// Number of 512B blocks allocated
+    pub st_blocks: i64,
+    /// Time of last access (seconds)
+    pub st_atime: i64,
+    /// Time of last access (nanoseconds)
+    pub st_atime_nsec: i64,
+    /// Time of last modification (seconds)
+    pub st_mtime: i64,
+    /// Time of last modification (nanoseconds)
+    pub st_mtime_nsec: i64,
+    /// Time of last status change (seconds)
+    pub st_ctime: i64,
+    /// Time of last status change (nanoseconds)
+    pub st_ctime_nsec: i64,
+    /// Unused
+    pub __unused: [i64; 3],
+}
+
+/// File type constants for st_mode
+pub mod mode {
+    /// Type of file mask
+    pub const S_IFMT: u32 = 0o170000;
+    /// Regular file
+    pub const S_IFREG: u32 = 0o100000;
+    /// Directory
+    pub const S_IFDIR: u32 = 0o040000;
+    /// Character device
+    pub const S_IFCHR: u32 = 0o020000;
+    /// Block device
+    pub const S_IFBLK: u32 = 0o060000;
+    /// FIFO (named pipe)
+    pub const S_IFIFO: u32 = 0o010000;
+    /// Symbolic link
+    pub const S_IFLNK: u32 = 0o120000;
+    /// Socket
+    pub const S_IFSOCK: u32 = 0o140000;
+}
+
+/// Trait for types that can provide stat information.
+pub trait StatAccess: FileAccess {
+    type StatError;
+
+    /// Get file status by file descriptor.
+    fn fstat(&self, fd: Self::Fd) -> Result<UserStat, Self::StatError>;
+}
+
+/// Get file status by file descriptor.
+pub fn sys_fstat<Cx: StatAccess>(
+    cx: &Cx,
+    fildes: Cx::Fd,
+    mut buf: UserspaceMutPtr<UserStat>,
+) -> Result<usize, Errno> {
+    if buf.as_ptr().is_null() {
+        return Err(EINVAL);
+    }
+
+    let stat = cx.fstat(fildes).map_err(|_| EBADF)?;
+
+    // Write stat to userspace buffer
+    unsafe {
+        core::ptr::write(buf.as_mut_ptr(), stat);
+    }
+
+    Ok(0)
+}


### PR DESCRIPTION
## Summary
- Add `lseek` method to `FileAccess` trait with `SEEK_SET`, `SEEK_CUR`, `SEEK_END` support
- Add `StatAccess` trait and `UserStat` structure for fstat operations
- Implement dispatch handlers for `SYS_CLOSE`, `SYS_LSEEK`, `SYS_FSTAT`
- Add userspace stat structure matching Linux ABI with file type mode constants

## Test plan
- [x] All 24 kernel_syscall tests pass
- [x] Kernel builds successfully for x86_64-unknown-none
- [x] Kernel library builds for aarch64-unknown-none