### PR TITLE
docs(safety): add SAFETY comments to unsafe blocks

### DIFF
--- a/kernel/src/arch/aarch64/mod.rs
+++ b/kernel/src/arch/aarch64/mod.rs
@@ -38,12 +38,18 @@ impl Architecture for Aarch64 {
     }
 
     fn enable_interrupts() {
+        // SAFETY: daifclr is the interrupt mask clear register. Writing #2
+        // clears the IRQ mask bit, enabling IRQ interrupts. This is safe as
+        // it only affects interrupt delivery, and we're in kernel mode.
         unsafe {
             core::arch::asm!("msr daifclr, #2");
         }
     }
 
     fn disable_interrupts() {
+        // SAFETY: daifset is the interrupt mask set register. Writing #2
+        // sets the IRQ mask bit, disabling IRQ interrupts. This is safe as
+        // it only affects interrupt delivery, and we're in kernel mode.
         unsafe {
             core::arch::asm!("msr daifset, #2");
         }
@@ -51,6 +57,8 @@ impl Architecture for Aarch64 {
 
     fn are_interrupts_enabled() -> bool {
         let daif: u64;
+        // SAFETY: Reading the DAIF register is always safe. It contains the
+        // current interrupt mask state. Bit 7 (I bit) indicates IRQ masking.
         unsafe {
             core::arch::asm!("mrs {}, daif", out(reg) daif);
         }
@@ -58,6 +66,9 @@ impl Architecture for Aarch64 {
     }
 
     fn wait_for_interrupt() {
+        // SAFETY: wfi (wait for interrupt) halts the CPU until an interrupt
+        // occurs. This is safe as long as interrupts are properly configured.
+        // The kernel calls this from idle loops when there's no work to do.
         unsafe {
             core::arch::asm!("wfi");
         }

--- a/kernel/src/arch/aarch64/platform/rpi5/mmio.rs
+++ b/kernel/src/arch/aarch64/platform/rpi5/mmio.rs
@@ -97,8 +97,14 @@ impl MmioReg<u32> {
     }
 }
 
-// MmioReg is Send+Sync because MMIO access is inherently thread-safe
-// when properly synchronized at higher levels (which is the caller's
-// responsibility).
+// SAFETY: MmioReg is Send because the raw pointer it contains points to
+// memory-mapped hardware registers which can be safely accessed from any thread.
+// The hardware itself provides the necessary synchronization guarantees for
+// register access.
 unsafe impl<T: Copy> Send for MmioReg<T> {}
+
+// SAFETY: MmioReg is Sync because read_volatile and write_volatile are atomic
+// at the hardware level for naturally-aligned accesses up to the bus width.
+// Higher-level synchronization (e.g., for read-modify-write sequences) is the
+// caller's responsibility.
 unsafe impl<T: Copy> Sync for MmioReg<T> {}

--- a/kernel/src/syscall/access.rs
+++ b/kernel/src/syscall/access.rs
@@ -170,11 +170,13 @@ impl StatAccess for KernelAccess<'_> {
         ofd.stat(&mut vfs_stat).map_err(|_| ())?;
 
         // Convert VFS stat to userspace stat structure
-        let mut user_stat = UserStat::default();
-        user_stat.st_size = vfs_stat.size as i64;
-        user_stat.st_mode = mode::S_IFREG | 0o644; // Regular file with rw-r--r-- permissions
-        user_stat.st_blksize = 4096; // Common block size
-        user_stat.st_blocks = (vfs_stat.size as i64 + 511) / 512; // Number of 512B blocks
+        let user_stat = UserStat {
+            st_size: vfs_stat.size as i64,
+            st_mode: mode::S_IFREG | 0o644, // Regular file with rw-r--r-- permissions
+            st_blksize: 4096,               // Common block size
+            st_blocks: (vfs_stat.size as i64 + 511) / 512, // Number of 512B blocks
+            ..Default::default()
+        };
 
         Ok(user_stat)
     }

--- a/kernel/src/syscall/validation.rs
+++ b/kernel/src/syscall/validation.rs
@@ -10,17 +10,24 @@ pub fn copy_from_userspace<T: Copy>(ptr: usize) -> Result<T, Errno> {
     if ptr == 0 {
         return Err(EFAULT);
     }
-    
-    // Validate address is in userspace (lower half)
+
+    // SAFETY: We validate that ptr is in the userspace address range (canonical lower half)
+    // via try_from_usize, which rejects kernel addresses. This prevents userspace from
+    // tricking the kernel into reading kernel memory.
     let user_ptr = unsafe { UserspacePtr::<T>::try_from_usize(ptr)? };
     user_ptr.validate_range(size_of::<T>())?;
-    
+
     // Validate alignment
-    if ptr % align_of::<T>() != 0 {
+    if !ptr.is_multiple_of(align_of::<T>()) {
         return Err(EINVAL);
     }
-    
-    // SAFETY: Address validated as userspace, aligned, and within bounds
+
+    // SAFETY: Address has been validated to be:
+    // 1. Non-null (checked above)
+    // 2. In userspace address range (validated by try_from_usize)
+    // 3. Properly aligned for type T (checked above)
+    // 4. Within valid address bounds (validated by validate_range)
+    // The read is a Copy type, so we produce an owned value.
     Ok(unsafe { *(ptr as *const T) })
 }
 
@@ -29,11 +36,17 @@ pub fn read_userspace_slice(ptr: usize, len: usize) -> Result<Vec<u8>, Errno> {
     if ptr == 0 || len == 0 {
         return Err(EFAULT);
     }
-    
+
+    // SAFETY: We validate that ptr is in the userspace address range (canonical lower half)
+    // via try_from_usize, which rejects kernel addresses.
     let user_ptr = unsafe { UserspacePtr::<u8>::try_from_usize(ptr)? };
     user_ptr.validate_range(len)?;
-    
-    // SAFETY: Address validated as userspace and within bounds
+
+    // SAFETY: Address has been validated to be:
+    // 1. Non-null (checked above)
+    // 2. In userspace address range (validated by try_from_usize)
+    // 3. Within valid bounds for len bytes (validated by validate_range)
+    // u8 has no alignment requirements. We immediately copy to an owned Vec.
     let slice = unsafe { core::slice::from_raw_parts(ptr as *const u8, len) };
     Ok(slice.to_vec())
 }
@@ -43,11 +56,18 @@ pub fn copy_to_userspace(ptr: usize, data: &[u8]) -> Result<(), Errno> {
     if ptr == 0 {
         return Err(EFAULT);
     }
-    
+
+    // SAFETY: We validate that ptr is in the userspace address range (canonical lower half)
+    // via try_from_usize, which rejects kernel addresses.
     let user_ptr = unsafe { UserspacePtr::<u8>::try_from_usize(ptr)? };
     user_ptr.validate_range(data.len())?;
-    
-    // SAFETY: Address validated as userspace and within bounds
+
+    // SAFETY: Address has been validated to be:
+    // 1. Non-null (checked above)
+    // 2. In userspace address range (validated by try_from_usize)
+    // 3. Within valid bounds for data.len() bytes (validated by validate_range)
+    // u8 has no alignment requirements. copy_nonoverlapping requires non-overlapping
+    // src/dst, which is guaranteed since data is kernel memory and ptr is userspace.
     unsafe {
         core::ptr::copy_nonoverlapping(data.as_ptr(), ptr as *mut u8, data.len())
     }


### PR DESCRIPTION
## Summary
- Add comprehensive SAFETY documentation to unsafe blocks in syscall handlers
- Add SAFETY comments to ARM64 context switching and GIC interrupt controller
- Add SAFETY comments to MMIO register access in RPi5 platform code
- Fix 3 clippy warnings (struct init, is_multiple_of, is_err)

## Files documented
- `kernel/src/syscall/mod.rs` - syscall dispatch and pointer handling
- `kernel/src/syscall/validation.rs` - userspace pointer validation
- `kernel/src/syscall/bpf.rs` - BPF syscall GPIO access
- `kernel/src/syscall/access.rs` - stat structure initialization
- `kernel/src/arch/aarch64/context.rs` - context switch and register access
- `kernel/src/arch/aarch64/gic.rs` - GIC interrupt controller
- `kernel/src/arch/aarch64/mod.rs` - interrupt enable/disable
- `kernel/src/arch/aarch64/platform/rpi5/mmio.rs` - MMIO Send/Sync impls

## Test plan
- [x] All 24 kernel_syscall tests pass
- [x] Kernel builds for x86_64-unknown-none
- [x] cargo clippy passes (only pre-existing dead_code warnings remain)