### PR TITLE
[WIP] feat: Raspberry Pi 5 Hardware Attach

### DIFF
--- a/kernel/crates/kernel_bpf/src/attach/gpio.rs
+++ b/kernel/crates/kernel_bpf/src/attach/gpio.rs
@@ -146,10 +146,9 @@ impl<P: PhysicalProfile> AttachPoint<P> for GpioAttach<P> {
         self.next_id += 1;
         self.attached.push(id);
 
-        // In a real implementation:
-        // 1. Open the GPIO chip via /dev/gpiochipN
-        // 2. Request the line with edge detection
-        // 3. Register a callback that invokes the BPF program
+        // Note: For Raspberry Pi 5, the hardware-level attachment is handled
+        // directly in kernel/src/arch/aarch64/platform/rpi5/gpio.rs via the
+        // sys_bpf(BPF_PROG_ATTACH) syscall.
 
         Ok(id)
     }

--- a/kernel/crates/kernel_bpf/src/attach/pwm.rs
+++ b/kernel/crates/kernel_bpf/src/attach/pwm.rs
@@ -133,10 +133,8 @@ impl<P: PhysicalProfile> AttachPoint<P> for PwmAttach<P> {
         self.next_id += 1;
         self.attached.push(id);
 
-        // In a real implementation:
-        // 1. Hook into the PWM subsystem (e.g., via kprobe on pwm_apply_state)
-        // 2. Filter for the specific chip/channel
-        // 3. Invoke the BPF program on each PWM state change
+        // Note: For Raspberry Pi 5, the hardware-level attachment is handled
+        // directly in kernel/src/arch/aarch64/platform/rpi5/pwm.rs.
 
         Ok(id)
     }

--- a/kernel/crates/kernel_physical_memory/src/types.rs
+++ b/kernel/crates/kernel_physical_memory/src/types.rs
@@ -16,7 +16,7 @@ impl PhysAddr {
 
     #[inline]
     pub const fn is_aligned(self, align: u64) -> bool {
-        self.0 % align == 0
+        self.0.wrapping_rem(align) == 0
     }
 
     #[inline]
@@ -77,6 +77,7 @@ impl<S: PageSize> PhysFrame<S> {
         }
     }
 
+    #[allow(clippy::result_unit_err)]
     pub const fn from_start_address(address: PhysAddr) -> Result<Self, ()> {
         if address.0 & (S::SIZE - 1) != 0 {
             return Err(());

--- a/kernel/crates/kernel_virtual_memory/src/addr.rs
+++ b/kernel/crates/kernel_virtual_memory/src/addr.rs
@@ -16,6 +16,7 @@ impl VirtAddr {
     }
 
     #[inline]
+    #[allow(clippy::result_unit_err)]
     pub fn try_new(addr: u64) -> Result<Self, ()> {
         // For now, we don't implement strict canonicality checks on AArch64
         // as they depend on the specific configuration (T0SZ, etc.)
@@ -39,7 +40,7 @@ impl VirtAddr {
 
     #[inline]
     pub const fn is_aligned(self, align: u64) -> bool {
-        self.0 % align == 0
+        self.0.wrapping_rem(align) == 0
     }
 
     #[inline]
@@ -112,6 +113,7 @@ impl<S: PageSize> Page<S> {
         }
     }
 
+    #[allow(clippy::result_unit_err)]
     pub const fn from_start_address(address: VirtAddr) -> Result<Self, ()> {
         if address.0 & (S::SIZE - 1) != 0 {
             return Err(());

--- a/kernel/crates/kernel_virtual_memory/src/segment.rs
+++ b/kernel/crates/kernel_virtual_memory/src/segment.rs
@@ -33,3 +33,10 @@ impl<S: PageSize> From<&Segment> for PageRangeInclusive<S> {
         }
     }
 }
+
+#[cfg(target_arch = "x86_64")]
+impl<S: PageSize> From<Segment> for PageRangeInclusive<S> {
+    fn from(value: Segment) -> Self {
+        Self::from(&value)
+    }
+}

--- a/kernel/src/arch/aarch64/boot.rs
+++ b/kernel/src/arch/aarch64/boot.rs
@@ -6,11 +6,11 @@ pub struct BootInfo {
 static mut BOOT_INFO: BootInfo = BootInfo { dtb_addr: 0 };
 
 #[inline(always)]
-fn dbg_mark(ch: u32) {
+fn dbg_mark(_ch: u32) {
     #[cfg(feature = "rpi5")]
     // SAFETY: Early debug marker write to Pi 5 debug UART10 data register.
     unsafe {
-        (0x10_7D00_1000 as *mut u32).write_volatile(ch);
+        (0x10_7D00_1000 as *mut u32).write_volatile(_ch);
     }
 }
 

--- a/kernel/src/arch/aarch64/cpu.rs
+++ b/kernel/src/arch/aarch64/cpu.rs
@@ -89,6 +89,11 @@ pub fn timer_tick() {
 /// This function performs the necessary barriers and cache maintenance
 /// to ensure that instructions written to memory are visible to the
 /// instruction fetch unit.
+///
+/// # Safety
+///
+/// The caller must ensure that the memory range [start, start + len) is
+/// valid and belongs to the JIT code region.
 #[no_mangle]
 pub unsafe extern "C" fn aarch64_jit_sync_cache(start: usize, len: usize) {
     // Get cache line sizes

--- a/kernel/src/arch/aarch64/exceptions.rs
+++ b/kernel/src/arch/aarch64/exceptions.rs
@@ -21,7 +21,7 @@ static INSTR_ABORT_MARKER_SENT: AtomicBool = AtomicBool::new(false);
 
 #[cfg(feature = "rpi5")]
 #[inline(always)]
-fn dbg_mark(ch: u32) {
+fn dbg_mark(_ch: u32) {
     const UART_BASE: usize = 0xFFFF_8010_7D00_1000;
     const UART_FR: usize = UART_BASE + 0x18;
     const UART_TXFF: u32 = 1 << 5;
@@ -29,7 +29,7 @@ fn dbg_mark(ch: u32) {
     unsafe {
         // Pace writes so marker bursts are not dropped when TX FIFO is full.
         while (UART_FR as *const u32).read_volatile() & UART_TXFF != 0 {}
-        (UART_BASE as *mut u32).write_volatile(ch);
+        (UART_BASE as *mut u32).write_volatile(_ch);
     }
 }
 

--- a/kernel/src/arch/aarch64/exceptions.rs
+++ b/kernel/src/arch/aarch64/exceptions.rs
@@ -187,6 +187,7 @@ pub extern "C" fn handle_sync_exception(ctx: &mut ExceptionContext) {
     let esr: u64;
     let elr: u64;
     let far: u64;
+    #[allow(unused_variables)]
     let spsr: u64;
 
     // SAFETY: Reading exception registers (ESR, ELR, FAR) is safe in an exception handler.

--- a/kernel/src/arch/aarch64/interrupts.rs
+++ b/kernel/src/arch/aarch64/interrupts.rs
@@ -48,10 +48,10 @@ static FIRST_IRQ_MARKER_SENT: AtomicBool = AtomicBool::new(false);
 
 #[cfg(feature = "rpi5")]
 #[inline(always)]
-fn dbg_mark(ch: u32) {
+fn dbg_mark(_ch: u32) {
     // SAFETY: Write to Pi 5 debug UART10 data register.
     unsafe {
-        (0xFFFF_8010_7D00_1000 as *mut u32).write_volatile(ch);
+        (0xFFFF_8010_7D00_1000 as *mut u32).write_volatile(_ch);
     }
 }
 

--- a/kernel/src/arch/aarch64/mm.rs
+++ b/kernel/src/arch/aarch64/mm.rs
@@ -275,18 +275,22 @@ pub fn create_user_address_space() -> Option<usize> {
         );
 
         // UART (PL011) at 0x0900_0000
-        walker.map_page(0x0900_0000, 0x0900_0000, device_flags.to_pte_bits()).ok()?;
+        walker
+            .map_page(0x0900_0000, 0x0900_0000, device_flags.to_pte_bits())
+            .ok()?;
 
         // Pi 5 debug connector UART10 (BCM2712 PL011) used by serial/log paths.
         // This MMIO must remain visible while TTBR0 is switched for process-AS operations.
         #[cfg(feature = "rpi5")]
         {
             use crate::arch::aarch64::platform::rpi5::memory_map::BCM2712_UART10_BASE_PHYS;
-            walker.map_page(
-                BCM2712_UART10_BASE_PHYS,
-                BCM2712_UART10_BASE_PHYS,
-                device_flags.to_pte_bits(),
-            ).ok()?;
+            walker
+                .map_page(
+                    BCM2712_UART10_BASE_PHYS,
+                    BCM2712_UART10_BASE_PHYS,
+                    device_flags.to_pte_bits(),
+                )
+                .ok()?;
         }
 
         #[cfg(feature = "rpi5")]
@@ -296,38 +300,48 @@ pub fn create_user_address_space() -> Option<usize> {
             };
 
             // Keep the Pi 5 GIC distributor + CPU interface visible while TTBR0 is active.
-            walker.map_range(
-                GICD_BASE_PHYS,
-                GICD_BASE_PHYS,
-                0x20000,
-                device_flags.to_pte_bits(),
-            ).ok()?;
-            walker.map_range(
-                GICC_BASE_PHYS,
-                GICC_BASE_PHYS,
-                0x20000,
-                device_flags.to_pte_bits(),
-            ).ok()?;
+            walker
+                .map_range(
+                    GICD_BASE_PHYS,
+                    GICD_BASE_PHYS,
+                    0x20000,
+                    device_flags.to_pte_bits(),
+                )
+                .ok()?;
+            walker
+                .map_range(
+                    GICC_BASE_PHYS,
+                    GICC_BASE_PHYS,
+                    0x20000,
+                    device_flags.to_pte_bits(),
+                )
+                .ok()?;
 
             // Map RP1 peripheral range using an efficient 1GB block mapping.
             // This replaces the previous 4KiB page-by-page mapping of the full range.
-            walker.map_l1_block(
-                RP1_PERIPHERAL_BASE_PHYS,
-                RP1_PERIPHERAL_BASE_PHYS,
-                device_flags.to_pte_bits(),
-            ).ok()?;
+            walker
+                .map_l1_block(
+                    RP1_PERIPHERAL_BASE_PHYS,
+                    RP1_PERIPHERAL_BASE_PHYS,
+                    device_flags.to_pte_bits(),
+                )
+                .ok()?;
         }
 
         #[cfg(all(feature = "virt", not(feature = "rpi5")))]
-        walker.map_range(
-            0x0800_0000,
-            0x0800_0000,
-            0x20000,
-            device_flags.to_pte_bits(),
-        ).ok()?;
+        walker
+            .map_range(
+                0x0800_0000,
+                0x0800_0000,
+                0x20000,
+                device_flags.to_pte_bits(),
+            )
+            .ok()?;
 
         // VirtIO MMIO at 0x0a00_0000 (32 devices * 512 bytes = 16KB)
-        walker.map_range(0x0a00_0000, 0x0a00_0000, 0x4000, device_flags.to_pte_bits()).ok()?;
+        walker
+            .map_range(0x0a00_0000, 0x0a00_0000, 0x4000, device_flags.to_pte_bits())
+            .ok()?;
 
         // Note: We leave the rest of 0-1GB unmapped so userspace can use it.
     }

--- a/kernel/src/arch/aarch64/mm.rs
+++ b/kernel/src/arch/aarch64/mm.rs
@@ -26,11 +26,11 @@ static mut BOOT_TABLES: BootPageTables = BootPageTables {
 };
 
 #[inline(always)]
-fn dbg_mark(ch: u32) {
+fn dbg_mark(_ch: u32) {
     #[cfg(feature = "rpi5")]
     // SAFETY: Early debug marker write to Pi 5 debug UART10 data register.
     unsafe {
-        (0x10_7D00_1000 as *mut u32).write_volatile(ch);
+        (0x10_7D00_1000 as *mut u32).write_volatile(_ch);
     }
 }
 

--- a/kernel/src/arch/aarch64/mm.rs
+++ b/kernel/src/arch/aarch64/mm.rs
@@ -275,18 +275,18 @@ pub fn create_user_address_space() -> Option<usize> {
         );
 
         // UART (PL011) at 0x0900_0000
-        let _ = walker.map_page(0x0900_0000, 0x0900_0000, device_flags.to_pte_bits());
+        walker.map_page(0x0900_0000, 0x0900_0000, device_flags.to_pte_bits()).ok()?;
 
         // Pi 5 debug connector UART10 (BCM2712 PL011) used by serial/log paths.
         // This MMIO must remain visible while TTBR0 is switched for process-AS operations.
         #[cfg(feature = "rpi5")]
         {
             use crate::arch::aarch64::platform::rpi5::memory_map::BCM2712_UART10_BASE_PHYS;
-            let _ = walker.map_page(
+            walker.map_page(
                 BCM2712_UART10_BASE_PHYS,
                 BCM2712_UART10_BASE_PHYS,
                 device_flags.to_pte_bits(),
-            );
+            ).ok()?;
         }
 
         #[cfg(feature = "rpi5")]
@@ -296,39 +296,38 @@ pub fn create_user_address_space() -> Option<usize> {
             };
 
             // Keep the Pi 5 GIC distributor + CPU interface visible while TTBR0 is active.
-            let _ = walker.map_range(
+            walker.map_range(
                 GICD_BASE_PHYS,
                 GICD_BASE_PHYS,
                 0x20000,
                 device_flags.to_pte_bits(),
-            );
-            let _ = walker.map_range(
+            ).ok()?;
+            walker.map_range(
                 GICC_BASE_PHYS,
                 GICC_BASE_PHYS,
                 0x20000,
                 device_flags.to_pte_bits(),
-            );
+            ).ok()?;
 
-            // Map RP1 peripheral range (1GB aperture)
-            // This contains GPIO, PWM, I2C, etc.
-            let _ = walker.map_range(
+            // Map RP1 peripheral range using an efficient 1GB block mapping.
+            // This replaces the previous 4KiB page-by-page mapping of the full range.
+            walker.map_l1_block(
                 RP1_PERIPHERAL_BASE_PHYS,
                 RP1_PERIPHERAL_BASE_PHYS,
-                0x4000_0000, // 1GB
                 device_flags.to_pte_bits(),
-            );
+            ).ok()?;
         }
 
         #[cfg(all(feature = "virt", not(feature = "rpi5")))]
-        let _ = walker.map_range(
+        walker.map_range(
             0x0800_0000,
             0x0800_0000,
             0x20000,
             device_flags.to_pte_bits(),
-        );
+        ).ok()?;
 
         // VirtIO MMIO at 0x0a00_0000 (32 devices * 512 bytes = 16KB)
-        let _ = walker.map_range(0x0a00_0000, 0x0a00_0000, 0x4000, device_flags.to_pte_bits());
+        walker.map_range(0x0a00_0000, 0x0a00_0000, 0x4000, device_flags.to_pte_bits()).ok()?;
 
         // Note: We leave the rest of 0-1GB unmapped so userspace can use it.
     }

--- a/kernel/src/arch/aarch64/mm.rs
+++ b/kernel/src/arch/aarch64/mm.rs
@@ -165,11 +165,10 @@ unsafe fn setup_kernel_page_tables(total_memory: usize) {
     #[cfg(feature = "rpi5")]
     {
         use crate::arch::aarch64::platform::rpi5::memory_map::{
-            BCM2712_UART10_BASE, GICC_BASE, GICD_BASE, RP1_PERIPHERAL_BASE,
+            BCM2712_UART10_BASE_PHYS, GICC_BASE_PHYS, GICD_BASE_PHYS, RP1_PERIPHERAL_BASE_PHYS,
         };
 
         // Keep Pi 5 high MMIO apertures accessible after MMU-on.
-        // Without this, post-MMU debug UART writes can fault immediately.
         let mmio_flags = pte_flags::VALID
             | pte_flags::AF
             | pte_flags::SH_INNER
@@ -177,13 +176,13 @@ unsafe fn setup_kernel_page_tables(total_memory: usize) {
             | pte_flags::PXN
             | pte_flags::attr_index(mem::mair::DEVICE_NGNRE);
 
-        for &mmio_base in &[
-            BCM2712_UART10_BASE,
-            GICD_BASE,
-            GICC_BASE,
-            RP1_PERIPHERAL_BASE,
+        for &phys_base in &[
+            BCM2712_UART10_BASE_PHYS,
+            GICD_BASE_PHYS,
+            GICC_BASE_PHYS,
+            RP1_PERIPHERAL_BASE_PHYS,
         ] {
-            let l1_idx = mmio_base >> 30; // 1GB block index
+            let l1_idx = phys_base >> 30; // 1GB block index
             if l1_idx < 512 {
                 let phys_addr = l1_idx << 30;
                 *boot_tables.l1_low.entry_mut(l1_idx) =
@@ -275,15 +274,32 @@ pub fn create_user_address_space() -> Option<usize> {
         // Pi 5 debug connector UART10 (BCM2712 PL011) used by serial/log paths.
         // This MMIO must remain visible while TTBR0 is switched for process-AS operations.
         #[cfg(feature = "rpi5")]
-        let _ = walker.map_page(0x10_7D00_1000, 0x10_7D00_1000, device_flags.to_pte_bits());
+        {
+            use crate::arch::aarch64::platform::rpi5::memory_map::BCM2712_UART10_BASE_PHYS;
+            let _ = walker.map_page(
+                BCM2712_UART10_BASE_PHYS,
+                BCM2712_UART10_BASE_PHYS,
+                device_flags.to_pte_bits(),
+            );
+        }
 
         #[cfg(feature = "rpi5")]
         {
-            use crate::arch::aarch64::platform::rpi5::memory_map::{GICC_BASE, GICD_BASE};
+            use crate::arch::aarch64::platform::rpi5::memory_map::{GICC_BASE_PHYS, GICD_BASE_PHYS};
 
             // Keep the Pi 5 GIC distributor + CPU interface visible while TTBR0 is active.
-            let _ = walker.map_range(GICD_BASE, GICD_BASE, 0x20000, device_flags.to_pte_bits());
-            let _ = walker.map_range(GICC_BASE, GICC_BASE, 0x20000, device_flags.to_pte_bits());
+            let _ = walker.map_range(
+                GICD_BASE_PHYS,
+                GICD_BASE_PHYS,
+                0x20000,
+                device_flags.to_pte_bits(),
+            );
+            let _ = walker.map_range(
+                GICC_BASE_PHYS,
+                GICC_BASE_PHYS,
+                0x20000,
+                device_flags.to_pte_bits(),
+            );
         }
 
         #[cfg(all(feature = "virt", not(feature = "rpi5")))]

--- a/kernel/src/arch/aarch64/mm.rs
+++ b/kernel/src/arch/aarch64/mm.rs
@@ -300,21 +300,12 @@ pub fn create_user_address_space() -> Option<usize> {
             };
 
             // Keep the Pi 5 GIC distributor + CPU interface visible while TTBR0 is active.
+            // These apertures overlap (GICC is 0x1000 above GICD), so we map them as one contiguous range.
+            let gic_start = GICD_BASE_PHYS;
+            let gic_end = GICC_BASE_PHYS + 0x20000;
+            let gic_size = gic_end - gic_start;
             walker
-                .map_range(
-                    GICD_BASE_PHYS,
-                    GICD_BASE_PHYS,
-                    0x20000,
-                    device_flags.to_pte_bits(),
-                )
-                .ok()?;
-            walker
-                .map_range(
-                    GICC_BASE_PHYS,
-                    GICC_BASE_PHYS,
-                    0x20000,
-                    device_flags.to_pte_bits(),
-                )
+                .map_range(gic_start, gic_start, gic_size, device_flags.to_pte_bits())
                 .ok()?;
 
             // Map RP1 peripheral range using an efficient 1GB block mapping.

--- a/kernel/src/arch/aarch64/mm.rs
+++ b/kernel/src/arch/aarch64/mm.rs
@@ -133,6 +133,7 @@ unsafe fn setup_kernel_page_tables(total_memory: usize) {
         let phys_addr = i << 30; // 1GB per entry
 
         // L1 block descriptor for 1GB mapping
+        #[allow(unused_mut)]
         let mut block_flags = pte_flags::VALID | pte_flags::AF | pte_flags::SH_INNER;
 
         // QEMU virt memory map:

--- a/kernel/src/arch/aarch64/mm.rs
+++ b/kernel/src/arch/aarch64/mm.rs
@@ -185,10 +185,16 @@ unsafe fn setup_kernel_page_tables(total_memory: usize) {
             let l1_idx = phys_base >> 30; // 1GB block index
             if l1_idx < 512 {
                 let phys_addr = l1_idx << 30;
+                // Map in identity region
                 *boot_tables.l1_low.entry_mut(l1_idx) =
                     paging::PageTableEntry::block(phys_addr, mmio_flags);
-                *boot_tables.l1_high.entry_mut(l1_idx) =
-                    paging::PageTableEntry::block(phys_addr, mmio_flags);
+
+                // Map in higher-half region ONLY if it doesn't conflict with kernel RAM (index 0)
+                // Pi 5 RAM starts at 0x0, so kernel is in index 0.
+                if l1_idx > 0 {
+                    *boot_tables.l1_high.entry_mut(l1_idx) =
+                        paging::PageTableEntry::block(phys_addr, mmio_flags);
+                }
             }
         }
     }
@@ -285,7 +291,9 @@ pub fn create_user_address_space() -> Option<usize> {
 
         #[cfg(feature = "rpi5")]
         {
-            use crate::arch::aarch64::platform::rpi5::memory_map::{GICC_BASE_PHYS, GICD_BASE_PHYS};
+            use crate::arch::aarch64::platform::rpi5::memory_map::{
+                GICC_BASE_PHYS, GICD_BASE_PHYS, RP1_PERIPHERAL_BASE_PHYS,
+            };
 
             // Keep the Pi 5 GIC distributor + CPU interface visible while TTBR0 is active.
             let _ = walker.map_range(
@@ -298,6 +306,15 @@ pub fn create_user_address_space() -> Option<usize> {
                 GICC_BASE_PHYS,
                 GICC_BASE_PHYS,
                 0x20000,
+                device_flags.to_pte_bits(),
+            );
+
+            // Map RP1 peripheral range (1GB aperture)
+            // This contains GPIO, PWM, I2C, etc.
+            let _ = walker.map_range(
+                RP1_PERIPHERAL_BASE_PHYS,
+                RP1_PERIPHERAL_BASE_PHYS,
+                0x4000_0000, // 1GB
                 device_flags.to_pte_bits(),
             );
         }

--- a/kernel/src/arch/aarch64/mod.rs
+++ b/kernel/src/arch/aarch64/mod.rs
@@ -21,8 +21,9 @@ pub struct Aarch64;
 fn dbg_mark(ch: u32) {
     #[cfg(feature = "rpi5")]
     // SAFETY: Early debug marker write to Pi 5 debug UART10 data register.
+    // Uses the virtual address from memory_map.
     unsafe {
-        (0x10_7D00_1000 as *mut u32).write_volatile(ch);
+        (platform::rpi5::memory_map::BCM2712_UART10_BASE as *mut u32).write_volatile(ch);
     }
 }
 

--- a/kernel/src/arch/aarch64/mod.rs
+++ b/kernel/src/arch/aarch64/mod.rs
@@ -21,9 +21,10 @@ pub struct Aarch64;
 fn dbg_mark(ch: u32) {
     #[cfg(feature = "rpi5")]
     // SAFETY: Early debug marker write to Pi 5 debug UART10 data register.
-    // Uses the virtual address from memory_map.
+    // ALWAYS use the physical address here so it works both before and after MMU is enabled
+    // (requires the address to be identity mapped in the page tables).
     unsafe {
-        (platform::rpi5::memory_map::BCM2712_UART10_BASE as *mut u32).write_volatile(ch);
+        (platform::rpi5::memory_map::BCM2712_UART10_BASE_PHYS as *mut u32).write_volatile(ch);
     }
 }
 

--- a/kernel/src/arch/aarch64/mod.rs
+++ b/kernel/src/arch/aarch64/mod.rs
@@ -18,13 +18,13 @@ use crate::arch::traits::Architecture;
 pub struct Aarch64;
 
 #[inline(always)]
-fn dbg_mark(ch: u32) {
+fn dbg_mark(_ch: u32) {
     #[cfg(feature = "rpi5")]
     // SAFETY: Early debug marker write to Pi 5 debug UART10 data register.
     // ALWAYS use the physical address here so it works both before and after MMU is enabled
     // (requires the address to be identity mapped in the page tables).
     unsafe {
-        (platform::rpi5::memory_map::BCM2712_UART10_BASE_PHYS as *mut u32).write_volatile(ch);
+        (platform::rpi5::memory_map::BCM2712_UART10_BASE_PHYS as *mut u32).write_volatile(_ch);
     }
 }
 

--- a/kernel/src/arch/aarch64/paging.rs
+++ b/kernel/src/arch/aarch64/paging.rs
@@ -8,8 +8,8 @@ use core::ptr;
 use bitflags::bitflags;
 
 use super::mem::{
-    mair, phys_to_virt, pte_flags, ENTRIES_PER_TABLE, L0_SHIFT, L1_SHIFT, L2_SHIFT, L3_SHIFT,
-    L1_BLOCK_SIZE, L2_BLOCK_SIZE, PAGE_SIZE,
+    mair, phys_to_virt, pte_flags, ENTRIES_PER_TABLE, L0_SHIFT, L1_BLOCK_SIZE, L1_SHIFT,
+    L2_BLOCK_SIZE, L2_SHIFT, L3_SHIFT, PAGE_SIZE,
 };
 use super::phys::{self};
 
@@ -249,13 +249,18 @@ impl PageTableWalker {
     }
 
     /// Map a 1GB block (L1 entry)
-    pub fn map_l1_block(&mut self, virt: usize, phys: usize, flags: u64) -> Result<(), &'static str> {
+    pub fn map_l1_block(
+        &mut self,
+        virt: usize,
+        phys: usize,
+        flags: u64,
+    ) -> Result<(), &'static str> {
         if virt & (L1_BLOCK_SIZE - 1) != 0 || phys & (L1_BLOCK_SIZE - 1) != 0 {
             return Err("Address not aligned to 1GB boundary");
         }
 
         let indices = va_to_indices(virt);
-        let l0 = unsafe { &mut *self.root };
+        let _l0 = unsafe { &mut *self.root };
         let l1_ptr = Self::get_or_create_table_ptr(self.root, indices[0])?;
         let l1 = unsafe { &mut *l1_ptr };
 
@@ -274,7 +279,12 @@ impl PageTableWalker {
     }
 
     /// Map a 2MB block (L2 entry)
-    pub fn map_l2_block(&mut self, virt: usize, phys: usize, flags: u64) -> Result<(), &'static str> {
+    pub fn map_l2_block(
+        &mut self,
+        virt: usize,
+        phys: usize,
+        flags: u64,
+    ) -> Result<(), &'static str> {
         if virt & (L2_BLOCK_SIZE - 1) != 0 || phys & (L2_BLOCK_SIZE - 1) != 0 {
             return Err("Address not aligned to 2MB boundary");
         }
@@ -545,6 +555,12 @@ pub fn get_ttbr1() -> usize {
     value
 }
 
+/// Configure MAIR_EL1
+///
+/// # Safety
+///
+/// This function is unsafe because it modifies the processor's memory
+/// attribute configuration.
 pub unsafe fn configure_mair() {
     unsafe {
         core::arch::asm!(
@@ -556,6 +572,12 @@ pub unsafe fn configure_mair() {
     }
 }
 
+/// Configure TCR_EL1
+///
+/// # Safety
+///
+/// This function is unsafe because it modifies the processor's translation
+/// control configuration.
 pub unsafe fn configure_tcr() {
     let tcr: u64 = 16               // T0SZ = 16 (48-bit VA)
                  | (16 << 16)       // T1SZ = 16 (48-bit VA)
@@ -582,6 +604,13 @@ pub fn init() {
     log::info!("ARM64 paging initialized (4KB granule, 48-bit VA)");
 }
 
+/// Enable the MMU
+///
+/// # Safety
+///
+/// This function is unsafe because it enables address translation, which
+/// will cause immediate page faults if the current execution flow is not
+/// properly mapped.
 pub unsafe fn enable_mmu() {
     let mut sctlr: u64;
     unsafe {

--- a/kernel/src/arch/aarch64/paging.rs
+++ b/kernel/src/arch/aarch64/paging.rs
@@ -9,7 +9,7 @@ use bitflags::bitflags;
 
 use super::mem::{
     mair, phys_to_virt, pte_flags, ENTRIES_PER_TABLE, L0_SHIFT, L1_SHIFT, L2_SHIFT, L3_SHIFT,
-    PAGE_SIZE,
+    L1_BLOCK_SIZE, L2_BLOCK_SIZE, PAGE_SIZE,
 };
 use super::phys::{self};
 
@@ -241,6 +241,56 @@ impl PageTableWalker {
         *entry = PageTableEntry::page(phys, flags);
 
         // Ensure the write is visible to the MMU and subsequent instruction fetches
+        unsafe {
+            core::arch::asm!("dsb ishst", "isb", options(nostack, preserves_flags));
+        }
+
+        Ok(())
+    }
+
+    /// Map a 1GB block (L1 entry)
+    pub fn map_l1_block(&mut self, virt: usize, phys: usize, flags: u64) -> Result<(), &'static str> {
+        if virt & (L1_BLOCK_SIZE - 1) != 0 || phys & (L1_BLOCK_SIZE - 1) != 0 {
+            return Err("Address not aligned to 1GB boundary");
+        }
+
+        let indices = va_to_indices(virt);
+        let l0 = unsafe { &mut *self.root };
+        let l1_ptr = Self::get_or_create_table_ptr(self.root, indices[0])?;
+        let l1 = unsafe { &mut *l1_ptr };
+
+        let entry = l1.entry_mut(indices[1]);
+        if entry.is_valid() {
+            return Err("L1 entry already mapped");
+        }
+
+        *entry = PageTableEntry::block(phys, flags);
+
+        unsafe {
+            core::arch::asm!("dsb ishst", "isb", options(nostack, preserves_flags));
+        }
+
+        Ok(())
+    }
+
+    /// Map a 2MB block (L2 entry)
+    pub fn map_l2_block(&mut self, virt: usize, phys: usize, flags: u64) -> Result<(), &'static str> {
+        if virt & (L2_BLOCK_SIZE - 1) != 0 || phys & (L2_BLOCK_SIZE - 1) != 0 {
+            return Err("Address not aligned to 2MB boundary");
+        }
+
+        let indices = va_to_indices(virt);
+        let l1_ptr = Self::get_or_create_table_ptr(self.root, indices[0])?;
+        let l2_ptr = Self::get_or_create_table_ptr(l1_ptr, indices[1])?;
+        let l2 = unsafe { &mut *l2_ptr };
+
+        let entry = l2.entry_mut(indices[2]);
+        if entry.is_valid() {
+            return Err("L2 entry already mapped");
+        }
+
+        *entry = PageTableEntry::block(phys, flags);
+
         unsafe {
             core::arch::asm!("dsb ishst", "isb", options(nostack, preserves_flags));
         }

--- a/kernel/src/arch/aarch64/phys.rs
+++ b/kernel/src/arch/aarch64/phys.rs
@@ -13,11 +13,11 @@ static mut BOOT_REGIONS: [crate::mem::phys::MemoryRegion; 8] =
     [crate::mem::phys::MemoryRegion { base: 0, length: 0 }; 8];
 
 #[inline(always)]
-fn dbg_mark(ch: u32) {
+fn dbg_mark(_ch: u32) {
     #[cfg(feature = "rpi5")]
-    // SAFETY: Early debug marker write to Pi 5 debug UART10 data register.
+    // SAFETY: Write to Pi 5 debug UART10 data register.
     unsafe {
-        (0x10_7D00_1000 as *mut u32).write_volatile(ch);
+        (0x10_7D00_1000 as *mut u32).write_volatile(_ch);
     }
 }
 

--- a/kernel/src/arch/aarch64/platform/rpi5/memory_map.rs
+++ b/kernel/src/arch/aarch64/platform/rpi5/memory_map.rs
@@ -6,17 +6,15 @@
 //! With firmware shortcuts enabled (pciex4_reset=0, enable_rp1_uart=1),
 //! the RP1 peripherals are pre-mapped to the CPU's physical address space.
 
+use crate::arch::aarch64::mem::phys_to_virt;
+
 /// RP1 peripheral base address (PCIe BAR1 window)
-///
-/// The RP1's internal address space (starting at 0x4000_0000) is mapped
-/// to this CPU physical address by the PCIe controller.
-pub const RP1_PERIPHERAL_BASE: usize = 0x1F_0000_0000;
+pub const RP1_PERIPHERAL_BASE_PHYS: usize = 0x1F_0000_0000;
+pub const RP1_PERIPHERAL_BASE: usize = phys_to_virt(RP1_PERIPHERAL_BASE_PHYS);
 
 /// BCM2712 primary/debug UART (PL011, uart10)
-///
-/// This is the console UART exposed on the Pi 5 debug connector
-/// and selected as the primary UART in upstream device trees.
-pub const BCM2712_UART10_BASE: usize = 0x10_7D00_1000;
+pub const BCM2712_UART10_BASE_PHYS: usize = 0x10_7D00_1000;
+pub const BCM2712_UART10_BASE: usize = phys_to_virt(BCM2712_UART10_BASE_PHYS);
 
 /// RP1 internal offset for UART0
 pub const RP1_UART0_OFFSET: usize = 0x0003_0000;
@@ -39,10 +37,10 @@ pub const RP1_PWM0_OFFSET: usize = 0x0009_8000;
 /// RP1 internal offset for PWM1
 pub const RP1_PWM1_OFFSET: usize = 0x0009_C000;
 
-/// Calculate CPU physical address for an RP1 peripheral
+/// Calculate CPU virtual address for an RP1 peripheral
 #[inline]
 pub const fn rp1_peripheral_addr(offset: usize) -> usize {
-    RP1_PERIPHERAL_BASE + offset
+    RP1_PERIPHERAL_BASE.wrapping_add(offset)
 }
 
 /// UART0 base address (PL011-compatible)
@@ -60,14 +58,13 @@ pub const RP1_PWM0_BASE: usize = rp1_peripheral_addr(RP1_PWM0_OFFSET);
 /// PWM1 base address
 pub const RP1_PWM1_BASE: usize = rp1_peripheral_addr(RP1_PWM1_OFFSET);
 
-/// ARM GIC-400 distributor base address (translated through the main SoC bus)
-///
-/// The Pi 5 DTB exposes the GIC at child addresses `0x7fff9000/0x7fffa000`
-/// under the `soc` bus, which maps to CPU physical `0x10_7fff9000/0x10_7fffa000`.
-pub const GICD_BASE: usize = 0x10_7FFF_9000;
+/// ARM GIC-400 distributor base address
+pub const GICD_BASE_PHYS: usize = 0x10_7FFF_9000;
+pub const GICD_BASE: usize = phys_to_virt(GICD_BASE_PHYS);
 
 /// ARM GIC-400 CPU interface base address
-pub const GICC_BASE: usize = 0x10_7FFF_A000;
+pub const GICC_BASE_PHYS: usize = 0x10_7FFF_A000;
+pub const GICC_BASE: usize = phys_to_virt(GICC_BASE_PHYS);
 
 /// Physical memory (DRAM) start
 pub const DRAM_BASE: usize = 0x0;

--- a/kernel/src/arch/aarch64/platform/rpi5/uart.rs
+++ b/kernel/src/arch/aarch64/platform/rpi5/uart.rs
@@ -41,6 +41,7 @@ mod reg {
 }
 
 /// Flag Register bits
+#[allow(dead_code)]
 mod fr {
     /// Transmit FIFO full
     pub const TXFF: u32 = 1 << 5;
@@ -51,6 +52,7 @@ mod fr {
 }
 
 /// Line Control Register bits
+#[allow(dead_code)]
 mod lcrh {
     /// Enable FIFOs
     pub const FEN: u32 = 1 << 4;
@@ -80,6 +82,7 @@ mod lcrh {
 }
 
 /// Control Register bits
+#[allow(dead_code)]
 mod cr {
     /// UART enable
     pub const UARTEN: u32 = 1 << 0;
@@ -171,16 +174,19 @@ impl Rp1Uart {
         unsafe { MmioReg::new(self.base + reg::FR) }
     }
 
+    #[allow(dead_code)]
     fn reg_lcrh(&self) -> MmioReg<u32> {
         // SAFETY: The base address is valid and the offset is within bounds.
         unsafe { MmioReg::new(self.base + reg::LCRH) }
     }
 
+    #[allow(dead_code)]
     fn reg_cr(&self) -> MmioReg<u32> {
         // SAFETY: The base address is valid and the offset is within bounds.
         unsafe { MmioReg::new(self.base + reg::CR) }
     }
 
+    #[allow(dead_code)]
     fn reg_icr(&self) -> MmioReg<u32> {
         // SAFETY: The base address is valid and the offset is within bounds.
         unsafe { MmioReg::new(self.base + reg::ICR) }

--- a/kernel/src/arch/mod.rs
+++ b/kernel/src/arch/mod.rs
@@ -32,9 +32,6 @@ pub mod riscv64;
 pub mod aarch64;
 
 #[cfg(target_arch = "aarch64")]
-pub use self::aarch64::*;
-
-#[cfg(target_arch = "aarch64")]
 #[derive(Debug, Clone, Copy)]
 #[repr(C)]
 pub struct UserContext {
@@ -43,8 +40,6 @@ pub struct UserContext {
 }
 
 // Re-export the current architecture
-#[cfg(target_arch = "aarch64")]
-pub use self::aarch64::*;
 #[cfg(target_arch = "riscv64")]
 pub use self::riscv64::*;
 #[cfg(target_arch = "aarch64")]

--- a/kernel/src/bpf/jit_memory.rs
+++ b/kernel/src/bpf/jit_memory.rs
@@ -32,7 +32,7 @@ pub mod aarch64 {
             return core::ptr::null_mut();
         }
 
-        let pages_needed = (size + PAGE_SIZE - 1) / PAGE_SIZE;
+        let pages_needed = size.div_ceil(PAGE_SIZE);
         let alloc_size = pages_needed * PAGE_SIZE;
 
         // Reserve virtual address space

--- a/kernel/src/bpf/mod.rs
+++ b/kernel/src/bpf/mod.rs
@@ -10,7 +10,9 @@ use kernel_bpf::bytecode::program::BpfProgram;
 use kernel_bpf::execution::{BpfContext, BpfError, BpfExecutor, Interpreter};
 use kernel_bpf::loader::BpfLoader;
 use kernel_bpf::maps::{ArrayMap, BpfMap, HashMap as BpfHashMap, RingBufMap, TimeSeriesMap};
-use kernel_bpf::profile::{ActiveProfile, PhysicalProfile};
+use kernel_bpf::profile::ActiveProfile;
+#[cfg(target_arch = "aarch64")]
+use kernel_bpf::profile::PhysicalProfile;
 
 pub const ATTACH_TYPE_TIMER: u32 = 1;
 pub const ATTACH_TYPE_GPIO: u32 = 2;

--- a/kernel/src/driver/virtio/hal.rs
+++ b/kernel/src/driver/virtio/hal.rs
@@ -187,7 +187,7 @@ unsafe impl Hal for HalImpl {
             let flags = pte_flags::DEVICE;
 
             walker
-                .map_range(vaddr_page, paddr_page, size_aligned, flags as u64)
+                .map_range(vaddr_page, paddr_page, size_aligned, flags)
                 .expect("Failed to map MMIO");
 
             // Flush TLB to ensure new mappings are visible

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -67,11 +67,11 @@ pub static BOOT_METRICS: OnceCell<KernelBootMetrics> = OnceCell::uninit();
 pub static BPF_MANAGER: OnceCell<Mutex<bpf::BpfManager>> = OnceCell::uninit();
 
 #[inline(always)]
-fn dbg_mark(ch: u32) {
+pub(crate) fn dbg_mark(_ch: u32) {
     #[cfg(feature = "rpi5")]
-    // SAFETY: Early debug marker write to Pi 5 debug UART10 data register.
+    // SAFETY: Write to Pi 5 debug UART10 data register.
     unsafe {
-        (0x10_7D00_1000 as *mut u32).write_volatile(ch);
+        (0x10_7D00_1000 as *mut u32).write_volatile(_ch);
     }
 }
 

--- a/kernel/src/log.rs
+++ b/kernel/src/log.rs
@@ -5,11 +5,11 @@ use crate::mcore::context::ExecutionContext;
 use crate::serial_println;
 
 #[inline(always)]
-fn dbg_mark(ch: u32) {
+fn dbg_mark(_ch: u32) {
     #[cfg(feature = "rpi5")]
-    // SAFETY: Early debug marker write to Pi 5 debug UART10 data register.
+    // SAFETY: Write to Pi 5 debug UART10 data register.
     unsafe {
-        (0x10_7D00_1000 as *mut u32).write_volatile(ch);
+        (0x10_7D00_1000 as *mut u32).write_volatile(_ch);
     }
 }
 

--- a/kernel/src/main.rs
+++ b/kernel/src/main.rs
@@ -27,7 +27,7 @@ use kernel::{
 use kernel_device::block::{BlockBuf, BlockDevice};
 #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
 use kernel_vfs::path::{AbsolutePath, ROOT};
-use log::{error, info};
+use log::info;
 #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
 use spin::RwLock;
 #[cfg(target_arch = "x86_64")]
@@ -91,11 +91,11 @@ unsafe extern "C" fn main() -> ! {
 // SAFETY: Kernel entry point.
 unsafe extern "C" fn main() -> ! {
     #[inline(always)]
-    fn dbg_mark(ch: u32) {
+    fn dbg_mark(_ch: u32) {
         #[cfg(feature = "rpi5")]
         // SAFETY: Early debug marker write to Pi 5 debug UART10 data register.
         unsafe {
-            (0x10_7D00_1000 as *mut u32).write_volatile(ch);
+            (0x10_7D00_1000 as *mut u32).write_volatile(_ch);
         }
     }
 

--- a/kernel/src/mcore/mtask/process/mem.rs
+++ b/kernel/src/mcore/mtask/process/mem.rs
@@ -209,7 +209,7 @@ impl MappedMemoryRegion {
             | PageTableFlags::NO_EXECUTE;
 
         new_process
-            .with_address_space(|as_| as_.map_range(&*new_segment, new_frames.into_iter(), flags))
+            .with_address_space(|as_| as_.map_range(*new_segment, new_frames.into_iter(), flags))
             .map_err(|_| "Failed to map memory in new process")?;
 
         Ok(MappedMemoryRegion {

--- a/kernel/src/mcore/mtask/process/mod.rs
+++ b/kernel/src/mcore/mtask/process/mod.rs
@@ -28,9 +28,9 @@ use x86_64::registers::rflags::RFlags;
 use x86_64::structures::idt::InterruptStackFrameValue;
 
 use crate::arch::{PageSize, Size4KiB, VirtAddr};
-use crate::file::{vfs, OpenFileDescription};
 #[cfg(feature = "rpi5")]
 use crate::dbg_mark;
+use crate::file::{vfs, OpenFileDescription};
 use crate::mcore::context::ExecutionContext;
 use crate::mcore::mtask::process::fd::{FdNum, FileDescriptor, FileDescriptorFlags};
 use crate::mcore::mtask::process::mem::MemoryRegions;

--- a/kernel/src/mcore/mtask/process/mod.rs
+++ b/kernel/src/mcore/mtask/process/mod.rs
@@ -90,15 +90,6 @@ static TRAMPOLINE_ENTER_USER_STAGE_SENT: AtomicBool = AtomicBool::new(false);
 #[cfg(all(target_arch = "aarch64", feature = "rpi5"))]
 static TRAMPOLINE_TTBR0_STAGE_SENT: AtomicBool = AtomicBool::new(false);
 
-#[cfg(all(target_arch = "aarch64", feature = "rpi5"))]
-#[inline(always)]
-fn dbg_mark(_ch: u32) {
-    // SAFETY: Write to Pi 5 debug UART10 data register through higher-half alias.
-    unsafe {
-        (0xFFFF_8010_7D00_1000 as *mut u32).write_volatile(_ch);
-    }
-}
-
 #[cfg(target_arch = "aarch64")]
 #[inline(always)]
 fn with_process_address_space_active<T, F>(process: &Arc<Process>, f: F) -> T

--- a/kernel/src/mcore/mtask/process/mod.rs
+++ b/kernel/src/mcore/mtask/process/mod.rs
@@ -884,10 +884,7 @@ extern "C" fn trampoline(_arg: *mut c_void) {
             #[cfg(all(target_arch = "aarch64", feature = "rpi5"))]
             dbg_mark(b'Q' as u32);
 
-            crate::arch::aarch64::context::enter_userspace(
-                code_ptr,
-                ustack_rsp.as_u64() as usize,
-            );
+            crate::arch::aarch64::context::enter_userspace(code_ptr, ustack_rsp.as_u64() as usize);
         }
     }
 }

--- a/kernel/src/mcore/mtask/process/mod.rs
+++ b/kernel/src/mcore/mtask/process/mod.rs
@@ -885,7 +885,7 @@ extern "C" fn trampoline(_arg: *mut c_void) {
             dbg_mark(b'Q' as u32);
 
             crate::arch::aarch64::context::enter_userspace(
-                code_ptr as usize,
+                code_ptr,
                 ustack_rsp.as_u64() as usize,
             );
         }

--- a/kernel/src/mcore/mtask/process/mod.rs
+++ b/kernel/src/mcore/mtask/process/mod.rs
@@ -29,6 +29,8 @@ use x86_64::structures::idt::InterruptStackFrameValue;
 
 use crate::arch::{PageSize, Size4KiB, VirtAddr};
 use crate::file::{vfs, OpenFileDescription};
+#[cfg(feature = "rpi5")]
+use crate::dbg_mark;
 use crate::mcore::context::ExecutionContext;
 use crate::mcore::mtask::process::fd::{FdNum, FileDescriptor, FileDescriptorFlags};
 use crate::mcore::mtask::process::mem::MemoryRegions;
@@ -90,10 +92,10 @@ static TRAMPOLINE_TTBR0_STAGE_SENT: AtomicBool = AtomicBool::new(false);
 
 #[cfg(all(target_arch = "aarch64", feature = "rpi5"))]
 #[inline(always)]
-fn dbg_mark(ch: u32) {
+fn dbg_mark(_ch: u32) {
     // SAFETY: Write to Pi 5 debug UART10 data register through higher-half alias.
     unsafe {
-        (0xFFFF_8010_7D00_1000 as *mut u32).write_volatile(ch);
+        (0xFFFF_8010_7D00_1000 as *mut u32).write_volatile(_ch);
     }
 }
 

--- a/kernel/src/mcore/mtask/scheduler/cleanup.rs
+++ b/kernel/src/mcore/mtask/scheduler/cleanup.rs
@@ -19,10 +19,10 @@ static CLEANUP_RUN_MARKER_SENT: Rpi5AtomicBool = Rpi5AtomicBool::new(false);
 
 #[cfg(all(target_arch = "aarch64", feature = "rpi5"))]
 #[inline(always)]
-fn dbg_mark(ch: u32) {
+fn dbg_mark(_ch: u32) {
     // SAFETY: Write to Pi 5 debug UART10 data register.
     unsafe {
-        (0x10_7D00_1000 as *mut u32).write_volatile(ch);
+        (0x10_7D00_1000 as *mut u32).write_volatile(_ch);
     }
 }
 

--- a/kernel/src/mcore/mtask/scheduler/mod.rs
+++ b/kernel/src/mcore/mtask/scheduler/mod.rs
@@ -37,10 +37,10 @@ static SCHED_SWITCH_TARGET_MARKER_SENT: AtomicBool = AtomicBool::new(false);
 
 #[cfg(all(target_arch = "aarch64", feature = "rpi5"))]
 #[inline(always)]
-fn dbg_mark(ch: u32) {
+fn dbg_mark(_ch: u32) {
     // SAFETY: Write to Pi 5 debug UART10 data register.
     unsafe {
-        (0x10_7D00_1000 as *mut u32).write_volatile(ch);
+        (0x10_7D00_1000 as *mut u32).write_volatile(_ch);
     }
 }
 

--- a/kernel/src/mcore/mtask/task/stack.rs
+++ b/kernel/src/mcore/mtask/task/stack.rs
@@ -1,6 +1,7 @@
 use core::ffi::c_void;
 use core::fmt::{Debug, Formatter};
-use core::mem::{size_of, size_of_val};
+use core::mem::size_of;
+#[cfg(target_arch = "x86_64")]
 use core::slice::from_raw_parts_mut;
 
 use kernel_virtual_memory::Segment;
@@ -199,7 +200,7 @@ impl HigherHalfStack {
             }
 
             // 2. Initialize stack with trampoline
-            let entry_point_addr = restore_user_context as usize;
+            let entry_point_addr = restore_user_context as *const () as usize;
             let arg_addr = context_addr;
             let exit_addr = 0; // restore_user_context does not return
 

--- a/kernel/src/mem/mod.rs
+++ b/kernel/src/mem/mod.rs
@@ -20,11 +20,11 @@ pub mod virt;
 
 #[cfg(target_arch = "aarch64")]
 #[inline(always)]
-fn dbg_mark(ch: u32) {
+fn dbg_mark(_ch: u32) {
     #[cfg(feature = "rpi5")]
     // SAFETY: Early debug marker write to Pi 5 debug UART10 data register.
     unsafe {
-        (0x10_7D00_1000 as *mut u32).write_volatile(ch);
+        (0x10_7D00_1000 as *mut u32).write_volatile(_ch);
     }
 }
 

--- a/kernel/src/mem/phys.rs
+++ b/kernel/src/mem/phys.rs
@@ -1,3 +1,5 @@
+#![allow(static_mut_refs)]
+
 use alloc::vec::Vec;
 use core::iter::from_fn;
 use core::mem::swap;
@@ -50,11 +52,11 @@ impl ReservedRegions {
 static mut RESERVED_REGIONS: ReservedRegions = ReservedRegions::new();
 
 #[inline(always)]
-fn dbg_mark(ch: u32) {
+fn dbg_mark(_ch: u32) {
     #[cfg(feature = "rpi5")]
-    // SAFETY: Early debug marker write to Pi 5 debug UART10 data register.
+    // SAFETY: Write to Pi 5 debug UART10 data register.
     unsafe {
-        (0x10_7D00_1000 as *mut u32).write_volatile(ch);
+        (0x10_7D00_1000 as *mut u32).write_volatile(_ch);
     }
 }
 

--- a/kernel/src/syscall/mod.rs
+++ b/kernel/src/syscall/mod.rs
@@ -65,11 +65,11 @@ static BPF_MARKER_SENT: AtomicBool = AtomicBool::new(false);
 
 #[cfg(feature = "rpi5")]
 #[inline(always)]
-fn dbg_mark(ch: u32) {
+fn dbg_mark(_ch: u32) {
     // SAFETY: Write to Pi 5 debug UART10 data register through the
     // higher-half direct map alias so this remains valid after TTBR0 switch.
     unsafe {
-        (0xFFFF_8010_7D00_1000 as *mut u32).write_volatile(ch);
+        (0xFFFF_8010_7D00_1000 as *mut u32).write_volatile(_ch);
     }
 }
 

--- a/userspace/init/src/main.rs
+++ b/userspace/init/src/main.rs
@@ -8,15 +8,15 @@ use minilib::write;
 pub extern "C" fn _start() -> ! {
     write(1, b"=== Axiom eBPF Init ===\n");
 
-    // Spawn safety_demo for hardware verification
-    write(1, b"Spawning /bin/safety_demo...\n");
-    let pid = minilib::spawn("/bin/safety_demo");
+    // Spawn benchmark for Pi5 performance measurement
+    write(1, b"Spawning /bin/benchmark...\n");
+    let pid = minilib::spawn("/bin/benchmark");
     if pid < 0 {
-        write(1, b"Failed to spawn safety_demo, errno=");
+        write(1, b"Failed to spawn benchmark, errno=");
         print_num((-pid) as u64);
         write(1, b"\n");
     } else {
-        write(1, b"Spawned safety_demo with PID: ");
+        write(1, b"Spawned benchmark with PID: ");
         print_num(pid as u64);
         write(1, b"\n");
     }

--- a/userspace/init/src/main.rs
+++ b/userspace/init/src/main.rs
@@ -8,15 +8,15 @@ use minilib::write;
 pub extern "C" fn _start() -> ! {
     write(1, b"=== Axiom eBPF Init ===\n");
 
-    // Spawn benchmark for Pi5 performance measurement
-    write(1, b"Spawning /bin/benchmark...\n");
-    let pid = minilib::spawn("/bin/benchmark");
+    // Spawn safety_demo for hardware verification
+    write(1, b"Spawning /bin/safety_demo...\n");
+    let pid = minilib::spawn("/bin/safety_demo");
     if pid < 0 {
-        write(1, b"Failed to spawn benchmark, errno=");
+        write(1, b"Failed to spawn safety_demo, errno=");
         print_num((-pid) as u64);
         write(1, b"\n");
     } else {
-        write(1, b"Spawned benchmark with PID: ");
+        write(1, b"Spawned safety_demo with PID: ");
         print_num(pid as u64);
         write(1, b"\n");
     }

--- a/userspace/safety_demo/src/main.rs
+++ b/userspace/safety_demo/src/main.rs
@@ -4,26 +4,13 @@
 use kernel_abi::BpfAttr;
 use minilib::{bpf, exit, write};
 
-// === Configuration ===
-// Limit switch pin (GPIO 22 — configurable for different wiring)
-const LIMIT_SWITCH_PIN: u32 = 22;
-// PWM configuration for simulated motor
-const PWM_CHIP: u32 = 0;
-const PWM_CHANNEL: u32 = 1;
-const MOTOR_DUTY: i32 = 50; // 50% duty cycle simulates running motor
+// Hardcoded for RPi5 Safety Demo
+const LIMIT_SWITCH_PIN: u32 = 17;
+const MOTOR_PWM_CHANNEL: u32 = 1;
 
-// === BPF Helper IDs (from interpreter/JIT dispatch tables) ===
+// BPF Helper IDs
+const HELPER_MOTOR_EMERGENCY_STOP: i32 = 1000;
 const HELPER_TRACE_PRINTK: i32 = 2;
-const HELPER_MOTOR_STOP: i32 = 1000;
-const HELPER_PWM_WRITE: i32 = 1005;
-
-// === BPF commands ===
-const BPF_PROG_LOAD: i32 = 5;
-const BPF_PROG_ATTACH: i32 = 8;
-
-// === Attach types ===
-const ATTACH_TYPE_TIMER: u32 = 1;
-const ATTACH_TYPE_GPIO: u32 = 2;
 
 #[repr(C)]
 struct BpfInsn {
@@ -33,287 +20,149 @@ struct BpfInsn {
     imm: i32,
 }
 
-#[allow(dead_code)]
-impl BpfInsn {
-    const fn mov64_imm(dst: u8, imm: i32) -> Self {
-        Self {
-            code: 0xb7,
-            dst_src: dst,
-            off: 0,
-            imm,
-        }
-    }
-
-    const fn mov64_reg(dst: u8, src: u8) -> Self {
-        Self {
-            code: 0xbf,
-            dst_src: (src << 4) | dst,
-            off: 0,
-            imm: 0,
-        }
-    }
-
-    const fn add64_imm(dst: u8, imm: i32) -> Self {
-        Self {
-            code: 0x07,
-            dst_src: dst,
-            off: 0,
-            imm,
-        }
-    }
-
-    /// Store 8-bit immediate to memory: *(u8*)(dst + off) = imm
-    const fn st_b(dst: u8, off: i16, imm: i32) -> Self {
-        Self {
-            code: 0x72,
-            dst_src: dst,
-            off,
-            imm,
-        }
-    }
-
-    const fn call(imm: i32) -> Self {
-        Self {
-            code: 0x85,
-            dst_src: 0,
-            off: 0,
-            imm,
-        }
-    }
-
-    const fn exit() -> Self {
-        Self {
-            code: 0x95,
-            dst_src: 0,
-            off: 0,
-            imm: 0,
-        }
-    }
+const fn regs(dst: u8, src: u8) -> u8 {
+    (src << 4) | (dst & 0x0f)
 }
 
-// SAFETY: Entry point for the safety interlock demo. Called by the startup code.
 #[unsafe(no_mangle)]
 pub extern "C" fn _start() -> ! {
     print("\n");
     print("========================================\n");
-    print("  Axiom Safety Interlock Demo\n");
-    print("========================================\n");
-    print("\n");
-    print("This demo proves: kernel-level BPF safety interlocks\n");
-    print("survive userspace exit. The interrupt -> BPF -> hardware\n");
-    print("path has ZERO userspace dependency.\n");
-    print("\n");
+    print("  AXIOM SAFETY INTERLOCK DEMO\n");
+    print("========================================\n\n");
 
-    // ---------------------------------------------------------
-    // Step 1: Start Motor — load a BPF program on the timer hook
-    //         that sets PWM0 channel 1 to 50% duty cycle.
-    //
-    // On each timer tick this program writes 50% to the PWM,
-    // simulating a running motor.
-    // ---------------------------------------------------------
-    print("[1/4] Starting motor (PWM0 Ch1 @ 50% duty)...\n");
+    print("Target: GPIO 17 (Limit Switch) -> PWM0 Emergency Stop\n");
 
-    let motor_insns = [
-        // R1 = PWM_CHIP (0)
-        BpfInsn::mov64_imm(1, PWM_CHIP as i32),
-        // R2 = PWM_CHANNEL (1)
-        BpfInsn::mov64_imm(2, PWM_CHANNEL as i32),
-        // R3 = duty (50%)
-        BpfInsn::mov64_imm(3, MOTOR_DUTY),
-        // call bpf_pwm_write(chip, channel, duty)
-        BpfInsn::call(HELPER_PWM_WRITE),
-        // R0 = 0 (success)
-        BpfInsn::mov64_imm(0, 0),
-        BpfInsn::exit(),
+    // BPF Logic:
+    // 1. R6 = R1 (context: GpioEvent)
+    // 2. R2 = *(u32 *)(R6 + 12)  // Load 'line'
+    // 3. if R2 != LIMIT_SWITCH_PIN, exit
+    // 4. R1 = 1 (reason code)
+    // 5. call bpf_motor_emergency_stop(R1)
+    // 6. R1 = address of string "Safety stop triggered!"
+    // 7. R2 = size of string
+    // 8. call bpf_trace_printk(R1, R2)
+    // 9. exit
+
+    let msg = "Safety stop triggered!\0";
+
+    let insns = [
+        // R6 = R1 (Save context pointer)
+        BpfInsn {
+            code: 0xbf,
+            dst_src: regs(6, 1),
+            off: 0,
+            imm: 0,
+        },
+        // R2 = *(u32 *)(R6 + 12)  // Load 'line' from GpioEvent
+        BpfInsn {
+            code: 0x61,
+            dst_src: regs(2, 6),
+            off: 12,
+            imm: 0,
+        },
+        // If R2 != LIMIT_SWITCH_PIN, goto EXIT
+        BpfInsn {
+            code: 0x55,
+            dst_src: regs(2, 0),
+            off: 6,
+            imm: LIMIT_SWITCH_PIN as i32,
+        },
+        // --- Safety Triggered ---
+
+        // R1 = 1 (Reason code for stop)
+        BpfInsn {
+            code: 0xb7,
+            dst_src: regs(1, 0),
+            off: 0,
+            imm: 1,
+        },
+        // Call bpf_motor_emergency_stop(R1)
+        BpfInsn {
+            code: 0x85,
+            dst_src: 0,
+            off: 0,
+            imm: HELPER_MOTOR_EMERGENCY_STOP,
+        },
+        // R1 = pointer to message (on stack or in program data)
+        // For simplicity in raw bytecode without a loader that handles relocations,
+        // we'll skip printk or use a fixed stack buffer if we really wanted to.
+        // Let's just do the emergency stop for now.
+
+        // EXIT:
+        BpfInsn {
+            code: 0xb7,
+            dst_src: regs(0, 0),
+            off: 0,
+            imm: 0,
+        }, // r0 = 0
+        BpfInsn {
+            code: 0x95,
+            dst_src: 0,
+            off: 0,
+            imm: 0,
+        }, // exit
     ];
 
-    let load_motor = BpfAttr {
-        prog_type: 1,
-        insn_cnt: motor_insns.len() as u32,
-        insns: motor_insns.as_ptr() as u64,
+    print("Loading Safety Interlock BPF program...\n");
+    let load_attr = BpfAttr {
+        prog_type: 1, // SocketFilter (generic)
+        insn_cnt: insns.len() as u32,
+        insns: insns.as_ptr() as u64,
         ..Default::default()
     };
 
-    let motor_id = bpf(
-        BPF_PROG_LOAD,
-        &load_motor as *const _ as *const u8,
+    let prog_id = bpf(
+        5, // BPF_PROG_LOAD
+        &load_attr as *const BpfAttr as *const u8,
         core::mem::size_of::<BpfAttr>() as i32,
     );
-    if motor_id < 0 {
-        print("  ERROR: Failed to load motor program\n");
+
+    if prog_id < 0 {
+        print("Error: Failed to load BPF program\n");
         exit(1);
     }
-    print("  Motor program loaded (ID: ");
-    print_num(motor_id as u64);
-    print(")\n");
 
-    // Attach motor program to timer so it runs on each tick
-    let attach_motor = BpfAttr {
-        attach_btf_id: ATTACH_TYPE_TIMER,
-        attach_prog_fd: motor_id as u32,
-        ..Default::default()
-    };
+    print("Program loaded. ID: ");
+    print_num(prog_id as u64);
+    print("\n");
 
-    let res = bpf(
-        BPF_PROG_ATTACH,
-        &attach_motor as *const _ as *const u8,
-        core::mem::size_of::<BpfAttr>() as i32,
-    );
-    if res < 0 {
-        print("  ERROR: Failed to attach motor to timer\n");
-        exit(1);
-    }
-    print("  Motor running on timer hook. PWM active.\n\n");
+    // Attach Program to GPIO Interrupt
+    print("Attaching to GPIO 17 (Rising Edge)...\n");
 
-    // ---------------------------------------------------------
-    // Step 2: Create E-Stop BPF program for GPIO interrupt
-    //
-    // When the limit switch fires (rising edge on LIMIT_SWITCH_PIN):
-    //   1. Call bpf_motor_emergency_stop(reason=1)
-    //   2. Call bpf_trace_printk("SAFETY: Motor stopped by limit switch!")
-    //   3. Return 0
-    //
-    // The trace_printk message will appear in kernel log, proving
-    // the BPF program executed in kernel interrupt context.
-    // ---------------------------------------------------------
-    print("[2/4] Loading E-Stop BPF program...\n");
-
-    // Build the trace message on the BPF stack.
-    // Message: "SAFETY: Motor stopped!\0" (22 bytes including NUL)
-    // We store it byte-by-byte using ST_B (store immediate byte).
-    // Stack layout: R10-32 .. R10-11 = message (22 bytes)
-    //
-    // "SAFETY: Motor stopped!\0"
-    // S=83 A=65 F=70 E=69 T=84 Y=89 :=58  =32
-    // M=77 o=111 t=116 o=111 r=114  =32
-    // s=115 t=116 o=111 p=112 p=112 e=101 d=100 !=33 \0=0
-
-    let estop_insns = [
-        // --- 1. Call bpf_motor_emergency_stop(reason=1) ---
-        // R1 = 1 (reason: limit switch triggered)
-        BpfInsn::mov64_imm(1, 1),
-        // call bpf_motor_emergency_stop
-        BpfInsn::call(HELPER_MOTOR_STOP),
-        // --- 2. Build trace message on stack and call bpf_trace_printk ---
-        // Store "SAFETY: Motor stopped!\0" at R10-24
-        BpfInsn::st_b(10, -24, b'S' as i32),
-        BpfInsn::st_b(10, -23, b'A' as i32),
-        BpfInsn::st_b(10, -22, b'F' as i32),
-        BpfInsn::st_b(10, -21, b'E' as i32),
-        BpfInsn::st_b(10, -20, b'T' as i32),
-        BpfInsn::st_b(10, -19, b'Y' as i32),
-        BpfInsn::st_b(10, -18, b':' as i32),
-        BpfInsn::st_b(10, -17, b' ' as i32),
-        BpfInsn::st_b(10, -16, b'M' as i32),
-        BpfInsn::st_b(10, -15, b'o' as i32),
-        BpfInsn::st_b(10, -14, b't' as i32),
-        BpfInsn::st_b(10, -13, b'o' as i32),
-        BpfInsn::st_b(10, -12, b'r' as i32),
-        BpfInsn::st_b(10, -11, b' ' as i32),
-        BpfInsn::st_b(10, -10, b's' as i32),
-        BpfInsn::st_b(10, -9, b't' as i32),
-        BpfInsn::st_b(10, -8, b'o' as i32),
-        BpfInsn::st_b(10, -7, b'p' as i32),
-        BpfInsn::st_b(10, -6, b'!' as i32),
-        BpfInsn::st_b(10, -5, 0), // NUL terminator
-        // R1 = pointer to string (R10 - 24)
-        BpfInsn::mov64_reg(1, 10),
-        BpfInsn::add64_imm(1, -24),
-        // R2 = size (20 = length of "SAFETY: Motor stop!" + NUL)
-        BpfInsn::mov64_imm(2, 20),
-        // call bpf_trace_printk
-        BpfInsn::call(HELPER_TRACE_PRINTK),
-        // --- 3. Return 0 ---
-        BpfInsn::mov64_imm(0, 0),
-        BpfInsn::exit(),
-    ];
-
-    let load_estop = BpfAttr {
-        prog_type: 1,
-        insn_cnt: estop_insns.len() as u32,
-        insns: estop_insns.as_ptr() as u64,
-        ..Default::default()
-    };
-
-    let estop_id = bpf(
-        BPF_PROG_LOAD,
-        &load_estop as *const _ as *const u8,
-        core::mem::size_of::<BpfAttr>() as i32,
-    );
-    if estop_id < 0 {
-        print("  ERROR: Failed to load E-Stop program\n");
-        exit(1);
-    }
-    print("  E-Stop program loaded (ID: ");
-    print_num(estop_id as u64);
-    print(")\n");
-    print("  Actions: bpf_motor_emergency_stop + bpf_trace_printk\n\n");
-
-    // ---------------------------------------------------------
-    // Step 3: Attach E-Stop to GPIO (limit switch pin, rising edge)
-    //
-    // The kernel's BPF_PROG_ATTACH handler for GPIO type will:
-    //   - Configure the pin as input
-    //   - Enable rising edge interrupt on the pin
-    //   - Register the BPF program for GPIO hook execution
-    // ---------------------------------------------------------
-    print("[3/4] Attaching E-Stop to GPIO ");
-    print_num(LIMIT_SWITCH_PIN as u64);
-    print(" (rising edge)...\n");
-
-    let attach_estop = BpfAttr {
-        attach_btf_id: ATTACH_TYPE_GPIO,
-        attach_prog_fd: estop_id as u32,
+    let attach_attr = BpfAttr {
+        attach_btf_id: 2, // ATTACH_TYPE_GPIO
+        attach_prog_fd: prog_id as u32,
         key: LIMIT_SWITCH_PIN as u64, // Pin number
-        value: 1,                     // 1 = Rising Edge
+        value: 1,                      // 1=Rising Edge
         ..Default::default()
     };
 
     let res = bpf(
-        BPF_PROG_ATTACH,
-        &attach_estop as *const _ as *const u8,
+        8, // BPF_PROG_ATTACH
+        &attach_attr as *const BpfAttr as *const u8,
         core::mem::size_of::<BpfAttr>() as i32,
     );
+
     if res < 0 {
-        print("  ERROR: Failed to attach E-Stop to GPIO\n");
+        print("Error: Failed to attach BPF program\n");
         exit(1);
     }
-    print("  E-Stop attached. GPIO interrupt armed.\n\n");
 
-    // ---------------------------------------------------------
-    // Step 4: EXIT — proving the safety thesis
-    //
-    // The BPF programs are now in the kernel:
-    //   - Motor program: timer hook -> PWM at 50%
-    //   - E-Stop program: GPIO interrupt -> motor emergency stop
-    //
-    // After this process exits:
-    //   - Programs PERSIST in the kernel's BpfManager
-    //   - GPIO interrupt -> BPF execute -> bpf_motor_emergency_stop
-    //   - This entire path is in kernel interrupt context
-    //   - ZERO userspace dependency
-    //
-    // Trigger the limit switch on GPIO 22 to verify.
-    // ---------------------------------------------------------
-    print("[4/4] Safety interlock ARMED.\n");
-    print("\n");
-    print("  Motor:     PWM0 Ch1 @ 50% (via timer BPF hook)\n");
-    print("  E-Stop:    GPIO ");
-    print_num(LIMIT_SWITCH_PIN as u64);
-    print(" rising edge -> bpf_motor_emergency_stop\n");
-    print("  Trace:     Kernel log will show 'SAFETY: Motor stop!'\n");
-    print("\n");
-    print("  >> Userspace will now EXIT. <<\n");
-    print("  >> Safety interlock remains active in the kernel. <<\n");
-    print("  >> Trigger limit switch on GPIO ");
-    print_num(LIMIT_SWITCH_PIN as u64);
-    print(" to stop motor. <<\n");
-    print("\n");
-    print("========================================\n");
-    print("  Exiting userspace. BPF persists.\n");
-    print("========================================\n");
+    print("Success! Safety Interlock ACTIVE.\n");
+    print("Simulating motor output on PWM0 Channel 1...\n");
 
-    exit(0);
+    // Note: We don't have a specific pwm_set syscall yet in minilib,
+    // but we can use the BPF helper via another BPF program or
+    // we could add a syscall.
+    // For this demo, let's assume the kernel has a default motor running
+    // or we just rely on the BPF program triggering the stop logic.
+
+    print("Ready. If GPIO 17 goes HIGH, the motor will be stopped in < 1us.\n");
+
+    loop {
+        minilib::sleep(1);
+    }
 }
 
 fn print(s: &str) {

--- a/userspace/safety_demo/src/main.rs
+++ b/userspace/safety_demo/src/main.rs
@@ -293,7 +293,7 @@ pub extern "C" fn _start() -> ! {
     //   - This entire path is in kernel interrupt context
     //   - ZERO userspace dependency
     //
-    // Trigger the limit switch on GPIO 22 to verify.
+    // Trigger the limit switch on GPIO 17 to verify.
     // ---------------------------------------------------------
     print("[4/4] Safety interlock ARMED.\n");
     print("\n");

--- a/userspace/safety_demo/src/main.rs
+++ b/userspace/safety_demo/src/main.rs
@@ -4,13 +4,26 @@
 use kernel_abi::BpfAttr;
 use minilib::{bpf, exit, write};
 
-// Hardcoded for RPi5 Safety Demo
+// === Configuration ===
+// Limit switch pin (GPIO 17 — configurable for different wiring)
 const LIMIT_SWITCH_PIN: u32 = 17;
-const MOTOR_PWM_CHANNEL: u32 = 1;
+// PWM configuration for simulated motor
+const PWM_CHIP: u32 = 0;
+const PWM_CHANNEL: u32 = 1;
+const MOTOR_DUTY: i32 = 50; // 50% duty cycle simulates running motor
 
-// BPF Helper IDs
-const HELPER_MOTOR_EMERGENCY_STOP: i32 = 1000;
+// === BPF Helper IDs (from interpreter/JIT dispatch tables) ===
 const HELPER_TRACE_PRINTK: i32 = 2;
+const HELPER_MOTOR_STOP: i32 = 1000;
+const HELPER_PWM_WRITE: i32 = 1005;
+
+// === BPF commands ===
+const BPF_PROG_LOAD: i32 = 5;
+const BPF_PROG_ATTACH: i32 = 8;
+
+// === Attach types ===
+const ATTACH_TYPE_TIMER: u32 = 1;
+const ATTACH_TYPE_GPIO: u32 = 2;
 
 #[repr(C)]
 struct BpfInsn {
@@ -20,149 +33,287 @@ struct BpfInsn {
     imm: i32,
 }
 
-const fn regs(dst: u8, src: u8) -> u8 {
-    (src << 4) | (dst & 0x0f)
-}
-
-#[unsafe(no_mangle)]
-pub extern "C" fn _start() -> ! {
-    print("\n");
-    print("========================================\n");
-    print("  AXIOM SAFETY INTERLOCK DEMO\n");
-    print("========================================\n\n");
-
-    print("Target: GPIO 17 (Limit Switch) -> PWM0 Emergency Stop\n");
-
-    // BPF Logic:
-    // 1. R6 = R1 (context: GpioEvent)
-    // 2. R2 = *(u32 *)(R6 + 12)  // Load 'line'
-    // 3. if R2 != LIMIT_SWITCH_PIN, exit
-    // 4. R1 = 1 (reason code)
-    // 5. call bpf_motor_emergency_stop(R1)
-    // 6. R1 = address of string "Safety stop triggered!"
-    // 7. R2 = size of string
-    // 8. call bpf_trace_printk(R1, R2)
-    // 9. exit
-
-    let msg = "Safety stop triggered!\0";
-
-    let insns = [
-        // R6 = R1 (Save context pointer)
-        BpfInsn {
-            code: 0xbf,
-            dst_src: regs(6, 1),
-            off: 0,
-            imm: 0,
-        },
-        // R2 = *(u32 *)(R6 + 12)  // Load 'line' from GpioEvent
-        BpfInsn {
-            code: 0x61,
-            dst_src: regs(2, 6),
-            off: 12,
-            imm: 0,
-        },
-        // If R2 != LIMIT_SWITCH_PIN, goto EXIT
-        BpfInsn {
-            code: 0x55,
-            dst_src: regs(2, 0),
-            off: 6,
-            imm: LIMIT_SWITCH_PIN as i32,
-        },
-        // --- Safety Triggered ---
-
-        // R1 = 1 (Reason code for stop)
-        BpfInsn {
+#[allow(dead_code)]
+impl BpfInsn {
+    const fn mov64_imm(dst: u8, imm: i32) -> Self {
+        Self {
             code: 0xb7,
-            dst_src: regs(1, 0),
+            dst_src: dst,
             off: 0,
-            imm: 1,
-        },
-        // Call bpf_motor_emergency_stop(R1)
-        BpfInsn {
+            imm,
+        }
+    }
+
+    const fn mov64_reg(dst: u8, src: u8) -> Self {
+        Self {
+            code: 0xbf,
+            dst_src: (src << 4) | dst,
+            off: 0,
+            imm: 0,
+        }
+    }
+
+    const fn add64_imm(dst: u8, imm: i32) -> Self {
+        Self {
+            code: 0x07,
+            dst_src: dst,
+            off: 0,
+            imm,
+        }
+    }
+
+    /// Store 8-bit immediate to memory: *(u8*)(dst + off) = imm
+    const fn st_b(dst: u8, off: i16, imm: i32) -> Self {
+        Self {
+            code: 0x72,
+            dst_src: dst,
+            off,
+            imm,
+        }
+    }
+
+    const fn call(imm: i32) -> Self {
+        Self {
             code: 0x85,
             dst_src: 0,
             off: 0,
-            imm: HELPER_MOTOR_EMERGENCY_STOP,
-        },
-        // R1 = pointer to message (on stack or in program data)
-        // For simplicity in raw bytecode without a loader that handles relocations,
-        // we'll skip printk or use a fixed stack buffer if we really wanted to.
-        // Let's just do the emergency stop for now.
+            imm,
+        }
+    }
 
-        // EXIT:
-        BpfInsn {
-            code: 0xb7,
-            dst_src: regs(0, 0),
-            off: 0,
-            imm: 0,
-        }, // r0 = 0
-        BpfInsn {
+    const fn exit() -> Self {
+        Self {
             code: 0x95,
             dst_src: 0,
             off: 0,
             imm: 0,
-        }, // exit
+        }
+    }
+}
+
+// SAFETY: Entry point for the safety interlock demo. Called by the startup code.
+#[unsafe(no_mangle)]
+pub extern "C" fn _start() -> ! {
+    print("\n");
+    print("========================================\n");
+    print("  Axiom Safety Interlock Demo\n");
+    print("========================================\n");
+    print("\n");
+    print("This demo proves: kernel-level BPF safety interlocks\n");
+    print("survive userspace exit. The interrupt -> BPF -> hardware\n");
+    print("path has ZERO userspace dependency.\n");
+    print("\n");
+
+    // ---------------------------------------------------------
+    // Step 1: Start Motor — load a BPF program on the timer hook
+    //         that sets PWM0 channel 1 to 50% duty cycle.
+    //
+    // On each timer tick this program writes 50% to the PWM,
+    // simulating a running motor.
+    // ---------------------------------------------------------
+    print("[1/4] Starting motor (PWM0 Ch1 @ 50% duty)...\n");
+
+    let motor_insns = [
+        // R1 = PWM_CHIP (0)
+        BpfInsn::mov64_imm(1, PWM_CHIP as i32),
+        // R2 = PWM_CHANNEL (1)
+        BpfInsn::mov64_imm(2, PWM_CHANNEL as i32),
+        // R3 = duty (50%)
+        BpfInsn::mov64_imm(3, MOTOR_DUTY),
+        // call bpf_pwm_write(chip, channel, duty)
+        BpfInsn::call(HELPER_PWM_WRITE),
+        // R0 = 0 (success)
+        BpfInsn::mov64_imm(0, 0),
+        BpfInsn::exit(),
     ];
 
-    print("Loading Safety Interlock BPF program...\n");
-    let load_attr = BpfAttr {
-        prog_type: 1, // SocketFilter (generic)
-        insn_cnt: insns.len() as u32,
-        insns: insns.as_ptr() as u64,
+    let load_motor = BpfAttr {
+        prog_type: 1,
+        insn_cnt: motor_insns.len() as u32,
+        insns: motor_insns.as_ptr() as u64,
         ..Default::default()
     };
 
-    let prog_id = bpf(
-        5, // BPF_PROG_LOAD
-        &load_attr as *const BpfAttr as *const u8,
+    let motor_id = bpf(
+        BPF_PROG_LOAD,
+        &load_motor as *const _ as *const u8,
         core::mem::size_of::<BpfAttr>() as i32,
     );
-
-    if prog_id < 0 {
-        print("Error: Failed to load BPF program\n");
+    if motor_id < 0 {
+        print("  ERROR: Failed to load motor program\n");
         exit(1);
     }
+    print("  Motor program loaded (ID: ");
+    print_num(motor_id as u64);
+    print(")\n");
 
-    print("Program loaded. ID: ");
-    print_num(prog_id as u64);
-    print("\n");
-
-    // Attach Program to GPIO Interrupt
-    print("Attaching to GPIO 17 (Rising Edge)...\n");
-
-    let attach_attr = BpfAttr {
-        attach_btf_id: 2, // ATTACH_TYPE_GPIO
-        attach_prog_fd: prog_id as u32,
-        key: LIMIT_SWITCH_PIN as u64, // Pin number
-        value: 1,                      // 1=Rising Edge
+    // Attach motor program to timer so it runs on each tick
+    let attach_motor = BpfAttr {
+        attach_btf_id: ATTACH_TYPE_TIMER,
+        attach_prog_fd: motor_id as u32,
         ..Default::default()
     };
 
     let res = bpf(
-        8, // BPF_PROG_ATTACH
-        &attach_attr as *const BpfAttr as *const u8,
+        BPF_PROG_ATTACH,
+        &attach_motor as *const _ as *const u8,
         core::mem::size_of::<BpfAttr>() as i32,
     );
-
     if res < 0 {
-        print("Error: Failed to attach BPF program\n");
+        print("  ERROR: Failed to attach motor to timer\n");
         exit(1);
     }
+    print("  Motor running on timer hook. PWM active.\n\n");
 
-    print("Success! Safety Interlock ACTIVE.\n");
-    print("Simulating motor output on PWM0 Channel 1...\n");
+    // ---------------------------------------------------------
+    // Step 2: Create E-Stop BPF program for GPIO interrupt
+    //
+    // When the limit switch fires (rising edge on LIMIT_SWITCH_PIN):
+    //   1. Call bpf_motor_emergency_stop(reason=1)
+    //   2. Call bpf_trace_printk("SAFETY: Motor stopped by limit switch!")
+    //   3. Return 0
+    //
+    // The trace_printk message will appear in kernel log, proving
+    // the BPF program executed in kernel interrupt context.
+    // ---------------------------------------------------------
+    print("[2/4] Loading E-Stop BPF program...\n");
 
-    // Note: We don't have a specific pwm_set syscall yet in minilib,
-    // but we can use the BPF helper via another BPF program or
-    // we could add a syscall.
-    // For this demo, let's assume the kernel has a default motor running
-    // or we just rely on the BPF program triggering the stop logic.
+    // Build the trace message on the BPF stack.
+    // Message: "SAFETY: Motor stopped!\0" (22 bytes including NUL)
+    // We store it byte-by-byte using ST_B (store immediate byte).
+    // Stack layout: R10-32 .. R10-11 = message (22 bytes)
+    //
+    // "SAFETY: Motor stopped!\0"
+    // S=83 A=65 F=70 E=69 T=84 Y=89 :=58  =32
+    // M=77 o=111 t=116 o=111 r=114  =32
+    // s=115 t=116 o=111 p=112 p=112 e=101 d=100 !=33 \0=0
 
-    print("Ready. If GPIO 17 goes HIGH, the motor will be stopped in < 1us.\n");
+    let estop_insns = [
+        // --- 1. Call bpf_motor_emergency_stop(reason=1) ---
+        // R1 = 1 (reason: limit switch triggered)
+        BpfInsn::mov64_imm(1, 1),
+        // call bpf_motor_emergency_stop
+        BpfInsn::call(HELPER_MOTOR_STOP),
+        // --- 2. Build trace message on stack and call bpf_trace_printk ---
+        // Store "SAFETY: Motor stopped!\0" at R10-24
+        BpfInsn::st_b(10, -24, b'S' as i32),
+        BpfInsn::st_b(10, -23, b'A' as i32),
+        BpfInsn::st_b(10, -22, b'F' as i32),
+        BpfInsn::st_b(10, -21, b'E' as i32),
+        BpfInsn::st_b(10, -20, b'T' as i32),
+        BpfInsn::st_b(10, -19, b'Y' as i32),
+        BpfInsn::st_b(10, -18, b':' as i32),
+        BpfInsn::st_b(10, -17, b' ' as i32),
+        BpfInsn::st_b(10, -16, b'M' as i32),
+        BpfInsn::st_b(10, -15, b'o' as i32),
+        BpfInsn::st_b(10, -14, b't' as i32),
+        BpfInsn::st_b(10, -13, b'o' as i32),
+        BpfInsn::st_b(10, -12, b'r' as i32),
+        BpfInsn::st_b(10, -11, b' ' as i32),
+        BpfInsn::st_b(10, -10, b's' as i32),
+        BpfInsn::st_b(10, -9, b't' as i32),
+        BpfInsn::st_b(10, -8, b'o' as i32),
+        BpfInsn::st_b(10, -7, b'p' as i32),
+        BpfInsn::st_b(10, -6, b'!' as i32),
+        BpfInsn::st_b(10, -5, 0), // NUL terminator
+        // R1 = pointer to string (R10 - 24)
+        BpfInsn::mov64_reg(1, 10),
+        BpfInsn::add64_imm(1, -24),
+        // R2 = size (20 = length of "SAFETY: Motor stop!" + NUL)
+        BpfInsn::mov64_imm(2, 20),
+        // call bpf_trace_printk
+        BpfInsn::call(HELPER_TRACE_PRINTK),
+        // --- 3. Return 0 ---
+        BpfInsn::mov64_imm(0, 0),
+        BpfInsn::exit(),
+    ];
 
-    loop {
-        minilib::sleep(1);
+    let load_estop = BpfAttr {
+        prog_type: 1,
+        insn_cnt: estop_insns.len() as u32,
+        insns: estop_insns.as_ptr() as u64,
+        ..Default::default()
+    };
+
+    let estop_id = bpf(
+        BPF_PROG_LOAD,
+        &load_estop as *const _ as *const u8,
+        core::mem::size_of::<BpfAttr>() as i32,
+    );
+    if estop_id < 0 {
+        print("  ERROR: Failed to load E-Stop program\n");
+        exit(1);
     }
+    print("  E-Stop program loaded (ID: ");
+    print_num(estop_id as u64);
+    print(")\n");
+    print("  Actions: bpf_motor_emergency_stop + bpf_trace_printk\n\n");
+
+    // ---------------------------------------------------------
+    // Step 3: Attach E-Stop to GPIO (limit switch pin, rising edge)
+    //
+    // The kernel's BPF_PROG_ATTACH handler for GPIO type will:
+    //   - Configure the pin as input
+    //   - Enable rising edge interrupt on the pin
+    //   - Register the BPF program for GPIO hook execution
+    // ---------------------------------------------------------
+    print("[3/4] Attaching E-Stop to GPIO ");
+    print_num(LIMIT_SWITCH_PIN as u64);
+    print(" (rising edge)...\n");
+
+    let attach_estop = BpfAttr {
+        attach_btf_id: ATTACH_TYPE_GPIO,
+        attach_prog_fd: estop_id as u32,
+        key: LIMIT_SWITCH_PIN as u64, // Pin number
+        value: 1,                     // 1 = Rising Edge
+        ..Default::default()
+    };
+
+    let res = bpf(
+        BPF_PROG_ATTACH,
+        &attach_estop as *const _ as *const u8,
+        core::mem::size_of::<BpfAttr>() as i32,
+    );
+    if res < 0 {
+        print("  ERROR: Failed to attach E-Stop to GPIO\n");
+        exit(1);
+    }
+    print("  E-Stop attached. GPIO interrupt armed.\n\n");
+
+    // ---------------------------------------------------------
+    // Step 4: EXIT — proving the safety thesis
+    //
+    // The BPF programs are now in the kernel:
+    //   - Motor program: timer hook -> PWM at 50%
+    //   - E-Stop program: GPIO interrupt -> motor emergency stop
+    //
+    // After this process exits:
+    //   - Programs PERSIST in the kernel's BpfManager
+    //   - GPIO interrupt -> BPF execute -> bpf_motor_emergency_stop
+    //   - This entire path is in kernel interrupt context
+    //   - ZERO userspace dependency
+    //
+    // Trigger the limit switch on GPIO 22 to verify.
+    // ---------------------------------------------------------
+    print("[4/4] Safety interlock ARMED.\n");
+    print("\n");
+    print("  Motor:     PWM0 Ch1 @ 50% (via timer BPF hook)\n");
+    print("  E-Stop:    GPIO ");
+    print_num(LIMIT_SWITCH_PIN as u64);
+    print(" rising edge -> bpf_motor_emergency_stop\n");
+    print("  Trace:     Kernel log will show 'SAFETY: Motor stop!'\n");
+    print("\n");
+    print("  >> Userspace will now EXIT. <<\n");
+    print("  >> Safety interlock remains active in the kernel. <<\n");
+    print("  >> Trigger limit switch on GPIO ");
+    print_num(LIMIT_SWITCH_PIN as u64);
+    print(" to stop motor. <<\n");
+    print("\n");
+    print("========================================\n");
+    print("  Exiting userspace. BPF persists.\n");
+    print("========================================\n");
+
+    exit(0);
 }
 
 fn print(s: &str) {


### PR DESCRIPTION
This PR advances Raspberry Pi 5 bring-up for AxiomOS and stabilizes hardware access for GPIO/PWM through the eBPF attach framework.

## Changes

- Refine GPIO and PWM attach abstractions
- Add `safety_demo` userspace application for hardware verification
- Fix bootstrap page table indexing using physical addresses
- Map hardware registers to prevent page faults
- Map RP1 peripheral aperture (1GB) for Pi 5 devices
- Use physical UART10 address for early boot debug
- Update init to spawn `safety_demo`

## Result

- Kernel boots without page faults
- RP1 peripherals (GPIO, PWM, I2C, etc.) accessible
- Hardware attach framework validated via `safety_demo`